### PR TITLE
Added custom_data and where_extra support

### DIFF
--- a/eve/auth.py
+++ b/eve/auth.py
@@ -72,6 +72,13 @@ class BasicAuth(object):
         return auth and self.check_auth(auth.username, auth.password,
                                         allowed_roles)
 
+    def username_field(self):
+        """ Return the filter used to restrict user to only access its own
+        resources.
+        """
+        if app.config['AUTH_USERNAME_FIELD']:
+            return {app.config['AUTH_USERNAME_FIELD']: request.authorization.username}
+
 
 class HMACAuth(BasicAuth):
     """ Hash Message Authentication Code (HMAC) authentication logic. Must be

--- a/eve/default_settings.py
+++ b/eve/default_settings.py
@@ -47,5 +47,7 @@ ITEM_LOOKUP = True
 ITEM_LOOKUP_FIELD = ID_FIELD
 ITEM_URL = '[a-f0-9]{24}'
 
+AUTH_USERNAME_FIELD = None      # Restrict API to user resources
+
 STATUS_OK = "OK"
 STATUS_ERR = "ERR"

--- a/eve/flaskapp.py
+++ b/eve/flaskapp.py
@@ -58,8 +58,7 @@ class Eve(Flask):
     :param kwargs: optional, standard, Flask parameters.
     """
     def __init__(self, import_name=__package__, settings='settings.py',
-                 validator=Validator, data=Mongo, auth=None,
-                 custom_data=None, **kwargs):
+                 validator=Validator, data=Mongo, auth=None, **kwargs):
         """Eve main WSGI app is implemented as a Flask subclass. Since we want
         to be able to launch our API by simply invoking Flask's run() method,
         we need to enhance our super-class a little bit.
@@ -89,8 +88,6 @@ class Eve(Flask):
 
         self.data = data(self)
         self.auth = auth() if auth else None
-
-        self.custom_data = custom_data
 
     def run(self, host=None, port=None, debug=None, **options):
         """Pass our own subclass of :class:`werkzeug.serving.WSGIRequestHandler

--- a/eve/io/mongo/mongo.py
+++ b/eve/io/mongo/mongo.py
@@ -84,9 +84,6 @@ class Mongo(DataLayer):
                 except ParseError:
                     abort(400)
 
-        if app.custom_data:
-            spec.update(app.custom_data())
-
         datasource, spec = self._datasource_ex(resource, spec)
 
         if req.if_modified_since:
@@ -123,7 +120,7 @@ class Mongo(DataLayer):
            retrieves the target collection via the new config.SOURCES helper.
         """
         datasource, filter_ = self._datasource_ex(resource)
-        return  self.driver.db[datasource].insert(document)
+        return self.driver.db[datasource].insert(document)
 
     def update(self, resource, id_, updates):
         """Updates a collection document.
@@ -179,4 +176,11 @@ class Mongo(DataLayer):
                 query.update(filter_)
             else:
                 query = filter_
+
+        if query is not None:
+            resource_user_restricted = app.config['DOMAIN'][resource].get('user_restricted')
+            if (app.config['AUTH_USERNAME_FIELD'] or resource_user_restricted)\
+                    and resource_user_restricted is not False:
+                query.update(app.auth.username_field())
+
         return datasource, query

--- a/eve/methods/post.py
+++ b/eve/methods/post.py
@@ -58,8 +58,10 @@ def post(resource):
                 document[config.LAST_UPDATED] = \
                     document[config.DATE_CREATED] = date_utc
 
-                if app.custom_data:
-                    document.update(app.custom_data())
+                resource_user_restricted = app.config['DOMAIN'][resource].get('user_restricted')
+                if (app.config['AUTH_USERNAME_FIELD'] or resource_user_restricted)\
+                        and resource_user_restricted is not False:
+                    document.update(app.auth.username_field())
 
                 document[config.ID_FIELD] = app.data.insert(resource, document)
 


### PR DESCRIPTION
First, eve is awesome ! I wish I discovered it earlier !

I wanted that an authenticated user can only retrieve resources he created, this mean, I need to add a user key on insert ( **custom_data** ), and override wheres query ( **where_extra** ) so a user can only retrieve its own resources.

I'm not sure about the name of these functions, but here how it works for me:

``` python
# -*- coding: utf-8 -*-
from eve import Eve
from eve.auth import TokenAuth
from flask import request


class TokenAuth(TokenAuth):
    def check_auth(self, token, allowed_roles):
        """For the purpose of this example the implementation is as simple as
        possible. A 'real' token should probably contain a hash of the
        username/password combo, which sould then validated against the account
        data stored on the DB.
        """
        # use Eve's own db driver; no additional connections/resources are used
        accounts = app.data.driver.db['accounts']
        return accounts.find_one({'token': token})


def custom_data():
    return {"user": request.authorization.username}
where_extra = custom_data

if __name__ == '__main__':
    app = Eve(auth=TokenAuth, custom_data=custom_data, where_extra=where_extra)
    app.debug = True
    app.run(host='0.0.0.0', port=8000)
```

Let me know if you want me to write tests (if you consider merging these changes), or if you have any feedback.

Thanks !
