### PR TITLE
add field projection for collections

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -14,3 +14,4 @@ Patches and Contributions
 - Kevin Bowrin
 - Gianfranco Palumbo
 - Nicolas Carlier
+- Nicolas Bazire <nicolas@linux.com>

--- a/eve/default_settings.py
+++ b/eve/default_settings.py
@@ -35,6 +35,7 @@ X_DOMAINS = None                # CORS disabled by default.
 
 FILTERS = True                  # filters enbaled by default.
 SORTING = True                  # sorting enabled by default.
+PROJECTION = True               # projection enabled by default
 PAGINATION = True               # pagination enabled by default.
 PAGINATION_LIMIT = 50
 PAGINATION_DEFAULT = 25

--- a/eve/flaskapp.py
+++ b/eve/flaskapp.py
@@ -306,6 +306,7 @@ class Eve(Flask):
             settings.setdefault('filters', self.config['FILTERS'])
             settings.setdefault('sorting', self.config['SORTING'])
             settings.setdefault('pagination', self.config['PAGINATION'])
+            settings.setdefault('projection', self.config['PROJECTION'])
             # TODO make sure that this we really need the test below
             if settings['item_lookup']:
                 item_methods = self.config['ITEM_METHODS']
@@ -319,6 +320,7 @@ class Eve(Flask):
             settings.setdefault('datasource', datasource)
             settings['datasource'].setdefault('source', resource)
             settings['datasource'].setdefault('filter', None)
+            settings['datasource'].setdefault('projection', None)
 
             # empty schemas are allowed for read-only access to resources
             schema = settings.setdefault('schema', {})

--- a/eve/io/base.py
+++ b/eve/io/base.py
@@ -135,10 +135,12 @@ class DataLayer(object):
 
     def _datasource(self, resource):
         """Returns a tuple with the actual name of the database
-        collection/table and the base query for the resource being accessed.
+        collection/table, base query and projection for the resource being
+        accessed.
 
         :param resource: resource being accessed.
         """
 
         return (config.SOURCES[resource]['source'],
-                config.SOURCES[resource]['filter'])
+                config.SOURCES[resource]['filter'],
+                config.SOURCES[resource]['projection'])

--- a/eve/io/mongo/mongo.py
+++ b/eve/io/mongo/mongo.py
@@ -73,6 +73,7 @@ class Mongo(DataLayer):
         if req.sort:
             args['sort'] = ast.literal_eval(req.sort)
 
+        fields = {}
         spec = {}
 
         if req.where:
@@ -84,7 +85,13 @@ class Mongo(DataLayer):
                 except ParseError:
                     abort(400)
 
-        datasource, spec = self._datasource_ex(resource, spec)
+        if req.projection:
+            try:
+                fields = json.loads(req.projection)
+            except:
+                abort(400)
+
+        datasource, spec, fields = self._datasource_ex(resource, spec, fields)
 
         if req.if_modified_since:
             spec[config.LAST_UPDATED] = \
@@ -92,6 +99,9 @@ class Mongo(DataLayer):
 
         if len(spec) > 0:
             args['spec'] = spec
+
+        if len(fields) > 0:
+            args['fields'] = fields
 
         return self.driver.db[datasource].find(**args)
 
@@ -109,7 +119,7 @@ class Mongo(DataLayer):
                 lookup[ID_FIELD] = ObjectId(lookup[ID_FIELD])
         except:
             pass
-        datasource, filter_ = self._datasource_ex(resource, lookup)
+        datasource, filter_, _ = self._datasource_ex(resource, lookup)
         document = self.driver.db[datasource].find_one(filter_)
         return document
 
@@ -123,7 +133,7 @@ class Mongo(DataLayer):
         .. versionchanged:: 0.0.4
            retrieves the target collection via the new config.SOURCES helper.
         """
-        datasource, filter_ = self._datasource_ex(resource)
+        datasource, filter_, _ = self._datasource_ex(resource)
         return self.driver.db[datasource].insert(doc_or_docs)
 
     def update(self, resource, id_, updates):
@@ -132,7 +142,7 @@ class Mongo(DataLayer):
         .. versionchanged:: 0.0.4
            retrieves the target collection via the new config.SOURCES helper.
         """
-        datasource, filter_ = self._datasource_ex(resource,
+        datasource, filter_, _ = self._datasource_ex(resource,
                                                   {ID_FIELD: ObjectId(id_)})
         return self.driver.db[datasource].update(filter_, {"$set": updates})
 
@@ -146,7 +156,7 @@ class Mongo(DataLayer):
             Support for deletion of entire documents collection.
         """
         query = {ID_FIELD: ObjectId(id_)} if id_ else None
-        datasource, filter_ = self._datasource_ex(resource, query)
+        datasource, filter_, _ = self._datasource_ex(resource, query)
         return self.driver.db[datasource].remove(filter_)
 
     def _jsondatetime(self, source):
@@ -167,7 +177,7 @@ class Mongo(DataLayer):
 
         return source
 
-    def _datasource_ex(self, resource, query=None):
+    def _datasource_ex(self, resource, query=None, fields=None):
         """ Returns both db collection and exact query (base filter included)
         to which an API resource refers to
 
@@ -177,12 +187,18 @@ class Mongo(DataLayer):
         .. versionadded:: 0.0.4
         """
 
-        datasource, filter_ = self._datasource(resource)
+        datasource, filter_, projection_ = self._datasource(resource)
         if filter_:
             if query:
                 query.update(filter_)
             else:
                 query = filter_
+
+        if projection_:
+            if fields:
+                fields.update(projection_)
+            else:
+                fields = projection_
 
         # if 'user-restricted resource access' is enabled and there's an Auth
         # request active, add the username field to the query
@@ -190,4 +206,4 @@ class Mongo(DataLayer):
         if username_field and request.authorization and query:
             query.update({username_field: request.authorization.username})
 
-        return datasource, query
+        return datasource, query, fields

--- a/eve/tests/config.py
+++ b/eve/tests/config.py
@@ -160,6 +160,7 @@ class TestConfig(TestBase):
         self.assertEqual(settings['item_title'],
                          resource.rstrip('s').capitalize())
         self.assertEqual(settings['filters'], self.app.config['FILTERS'])
+        self.assertEqual(settings['projection'], self.app.config['PROJECTION'])
         self.assertEqual(settings['sorting'], self.app.config['SORTING'])
         self.assertEqual(settings['pagination'], self.app.config['PAGINATION'])
         self.assertEqual(settings['auth_username_field'],
@@ -169,7 +170,8 @@ class TestConfig(TestBase):
         self.assertEqual(type(settings['schema']), dict)
         self.assertEqual(len(settings['schema']), 0)
         self.assertEqual(settings['datasource'],
-                         {'source': resource, 'filter': None})
+                         {'source': resource, 'filter': None,
+                          'projection': None})
 
     def test_validate_roles(self):
         for resource in self.domain:

--- a/eve/tests/methods/get.py
+++ b/eve/tests/methods/get.py
@@ -95,6 +95,18 @@ class TestGet(TestBase):
         resource = response['_items']
         self.assertEqual(len(resource), 1)
 
+    def test_get_projection(self):
+        projection = '{"prog": 1}'
+        response, status = self.get(self.known_resource, '?projection=%s' % projection)
+        self.assert200(status)
+
+        resource = response['_items']
+
+        for r in resource:
+            self.assertFalse(r.has_key('location'))
+            self.assertFalse(r.has_key('role'))
+            self.assertTrue(r.has_key('prog'))
+
     def test_get_where_disabled(self):
         self.app.config['DOMAIN'][self.known_resource]['filters'] = False
         where = 'ref == %s' % self.item_name

--- a/eve/utils.py
+++ b/eve/utils.py
@@ -46,6 +46,9 @@ class ParsedRequest(object):
     # `where` value of the query string (?where). Defaults to None.
     where = None
 
+    # `projection` value of the query string (?projection). Defaults to None.
+    projection = None
+
     # `sort` value of the query string (?sort). Defaults to None.
     sort = None
 
@@ -88,6 +91,8 @@ def parse_request(resource=None, args=None, headers=None):
     if args:
         if resource is None or config.DOMAIN[resource]['filters']:
             r.where = args.get('where')
+        if resource is None or config.DOMAIN[resource]['projection']:
+            r.projection = args.get('projection')
         if resource is None or config.DOMAIN[resource]['sorting']:
             r.sort = args.get('sort')
 


### PR DESCRIPTION
This feature allows to create "views" of collections, or more
precisely decide what fields should or should not be returned
using a projection.

More info :
http://docs.mongodb.org/manual/reference/glossary/#term-projection
