### PR TITLE
Security issue with User-Restricted Resource Access

### DIFF
--- a/eve/io/mongo/mongo.py
+++ b/eve/io/mongo/mongo.py
@@ -219,7 +219,7 @@ class Mongo(DataLayer):
         # if 'user-restricted resource access' is enabled and there's an Auth
         # request active, add the username field to the query
         username_field = config.DOMAIN[resource].get('auth_username_field')
-        if username_field and request.authorization and query:
+        if username_field and request.authorization:
             query.update({username_field: request.authorization.username})
 
         return datasource, query, fields


### PR DESCRIPTION
I found a security issue, the query should be updated with the <code>auth_username_field</code> even when a GET with no parameters is performed, a user should only see the items he created.

The fix works for me. Keep me updated !
