### PR TITLE
[WIP] Payload now correctly splits Content-Type

### DIFF
--- a/eve/methods/common.py
+++ b/eve/methods/common.py
@@ -95,9 +95,11 @@ def payload():
 
     .. versionadded: 0.0.5
     """
-    if request.headers['Content-Type'] == 'application/json':
+    content_type = request.headers['Content-Type'].split(';')[0]
+
+    if content_type == 'application/json':
         return json.loads(request.data)
-    elif request.headers['Content-Type'] == \
+    elif content_type == \
             'application/x-www-form-urlencoded':
         return request.form if len(request.form) else abort(400)
     else:

--- a/eve/methods/post.py
+++ b/eve/methods/post.py
@@ -46,7 +46,7 @@ def post(resource):
        Support for 'user-restricted resource access'.
 
     .. versionchanged:: 0.0.4
-       Added the ``reqiores_auth`` decorator.
+       Added the ``requires_auth`` decorator.
 
     .. versionchanged:: 0.0.3
        JSON links. Superflous ``response`` container removed.

--- a/eve/tests/methods/post.py
+++ b/eve/tests/methods/post.py
@@ -173,6 +173,15 @@ class TestPost(TestBase):
         self.assert200(status)
         self.assertPostResponse(r, ['item1'])
 
+    def test_post_with_content_type_charset(self):
+        test_field = 'ref'
+        test_value = "1234567890123456789054321"
+        data = {'item1': json.dumps({test_field: test_value})}
+        r, status = self.post(self.known_resource_url, data=data,
+                  content_type='application/json; charset=utf-8')
+        self.assert200(status)
+        self.assertPostResponse(r, ['item1'])
+
     def perform_post(self, data, valid_items=['item1']):
         r, status = self.post(self.known_resource_url, data=data)
         self.assert200(status)


### PR DESCRIPTION
Commit message should be clear, but I'm going to clarify the case anyway:

I was finally going through tutorial of Eve, but instead of `curl` I used [`httpie`](https://github.com/jkbr/httpie) which automatically appends `; charset=utf-8` to `Content-Type` header. `payload` method wasn't taking this scenario into account and I was getting 400s.

The fix is not that tricky and tests are passing, but I found out it's false sense of security. There's probably something wrong with Werkzeug's test client. It seems it's somehow converting any `Content-Type` to `application/x-www-form-urlencoded`. So my new test and JSON tests are most likely not testing what they should. It's all ok inside Werkzeug until this point: https://github.com/mitsuhiko/werkzeug/blob/master/werkzeug/test.py#L745, then some black magic takes place and I have no idea what happens to these data. I lost good deal of the afternoon digging into it and I think I might be just missing something obvious, so I'm passing it here.

Just to further clarify, the fix actually works for me if I test it manually, just unit tests are acting up.
