### PR TITLE
find_one() parses ObjectId() if auth_username_field='_id'

### DIFF
--- a/eve/io/mongo/mongo.py
+++ b/eve/io/mongo/mongo.py
@@ -131,13 +131,14 @@ class Mongo(DataLayer):
         .. versionchanged:: 0.0.4
            retrieves the target collection via the new config.SOURCES helper.
         """
+        datasource, filter_, projection = self._datasource_ex(resource, lookup)
+
         try:
-            if config.ID_FIELD in lookup:
-                lookup[ID_FIELD] = ObjectId(lookup[ID_FIELD])
+            if config.ID_FIELD in filter_:
+                filter_[ID_FIELD] = ObjectId(filter_[ID_FIELD])
         except:
             pass
 
-        datasource, filter_, projection = self._datasource_ex(resource, lookup)
         document = self.driver.db[datasource].find_one(filter_, projection)
         return document
 


### PR DESCRIPTION
According to [this comment](https://github.com/nicolaiarocci/eve/issues/46#issuecomment-16785003) you're supposed to be able to set `auth_username_field` to `ID_FIELD`.

However, this bypasses the conversion [here](https://github.com/nicolaiarocci/eve/blob/develop/eve/io/mongo/mongo.py#L136) where `ID_FIELD` is converted to an `ObjectId`:

```
try:
    if config.ID_FIELD in lookup:
        lookup[ID_FIELD] = ObjectId(lookup[ID_FIELD])
except:
    pass
```

Running `_datasource_ex()` before the above fixes this. 
