### PR TITLE
Add support for event hooks of the type "on_getting_<item_title>"

### DIFF
--- a/eve/methods/get.py
+++ b/eve/methods/get.py
@@ -161,9 +161,9 @@ def getitem(resource, **lookup):
         # state on the database).
         item_title = config.DOMAIN[resource]['item_title'].lower()
 
+        getattr(app, "on_getting_%s" % item_title)(document[config.ID_FIELD], document)
         getattr(app, "on_getting_item")(resource, document[config.ID_FIELD],
                                         document)
-        getattr(app, "on_getting_%s" % item_title)(document[config.ID_FIELD], document)
 
         response.update(document)
         return response, last_modified, document['etag'], 200


### PR DESCRIPTION
Add support for event hooks that are triggered when a specific type of document is read from the database (e.g. on_getting_person will be triggered when a GET request is performed on /people/<_id>).
