### PR TITLE
Fix CORS for additional_lookup urls.

### DIFF
--- a/eve/flaskapp.py
+++ b/eve/flaskapp.py
@@ -512,7 +512,7 @@ class Eve(Flask, Events):
                                                             lookup['url'],
                                                             lookup['field'])
                     self.add_url_rule(item_url, view_func=item_endpoint,
-                                      methods=['GET'])
+                                      methods=['GET', 'OPTIONS'])
         self.config['RESOURCES'] = resources
         self.config['URLS'] = urls
         self.config['SOURCES'] = datasources


### PR DESCRIPTION
Currently OPTIONS are not handled for additional_lookups within the app so there are no CORS related headers in the response.
