### PR TITLE
doc roles schema definition

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -597,10 +597,13 @@ streams.
             'required': True,
             'unique': True,
         },
-        # 'role' is a list, and can only contain values from 'allowed'.
-        'role': {
+        # 'roles' is a list, and can only contain values from 'allowed'.
+        'roles': {
             'type': 'list',
-            'allowed': ["author", "contributor", "copy"],
+            'schema': {
+			    'type': 'string',
+				'allowed': ["author", "contributor", "copy"],
+				},
         },
         # An embedded 'strongly-typed' dictionary.
         'location': {


### PR DESCRIPTION
I think it supposed to be 'roles' instead of 'role'
