### PR TITLE
Use item_lookup_field instead of ID_FIELD for DELETE methods

### DIFF
--- a/eve/methods/delete.py
+++ b/eve/methods/delete.py
@@ -39,7 +39,7 @@ def delete(resource, **lookup):
     if not original:
         abort(404)
 
-    app.data.remove(resource, lookup[config.ID_FIELD])
+    app.data.remove(resource, original[config.ID_FIELD])
     return {}, None, None, 200
 
 


### PR DESCRIPTION
Existing code uses lookup to recover document. Once we've found the
"original" document we don't need lookup anymore and we can use
"original" document ID_FIELD.
Using lookup[ID_FIELD] forces to use just the ID_FIELD on path.

This change would be consistent with GET and PATCH methods where
changing item_lookup_field let items to be recovered/updated with other
fields than _id (or ID_FIELD for global configuration)
