### PR TITLE
typo mistake

### DIFF
--- a/docs/features.rst
+++ b/docs/features.rst
@@ -658,7 +658,7 @@ toggling the ``embedding`` value). Furthermore, only fields with the
 referenced documents.
 
 Limitations: currenly we only support a single layer of embedding, i.e.
-``/emails?{"author": 1}`` but *not* ``/emails?{"author.firends": 1}``. This
+``/emails?embedded={"author": 1}`` but *not* ``/emails?embedded={"author.friends": 1}``. This
 feature is about serialization on GET requests. There's no support for POST,
 PUT or PATCH of embedded documents.
 


### PR DESCRIPTION
I think there is a typo mistake here. although a 'friends' field in 'author' doesn't seems to fit.

also, there was missing the 'embedded=' at the url
