### PR TITLE
XML leaf values are not escaped

### DIFF
--- a/eve/render.py
+++ b/eve/render.py
@@ -325,6 +325,9 @@ def xml_dict(data):
 
     :param data: the data stream to be rendered as xml.
 
+    .. versionchanged:: 0.1.2
+       Leaf values are now properly escaped.
+
     .. versionadded:: 0.0.3
     """
     xml = ''
@@ -343,5 +346,5 @@ def xml_dict(data):
                 xml += links
                 xml += "</%s>" % k
             else:
-                xml += "<%s>%s</%s>" % (k, value, k)
+                xml += "<%s>%s</%s>" % (k, utils.escape(value), k)
     return xml


### PR DESCRIPTION
When serving XML, "unsafe" data e.g. a URL with an `&` in it, the XML response Eve returns is malformed, leading to errors like

```
error on line 1 at column 63381: EntityRef: expecting ';'
```

The problem is that leaf values are not escaped.
