### PR TITLE
update MongoJSONEncoder to use pymongos json_util

### DIFF
--- a/eve/io/mongo/mongo.py
+++ b/eve/io/mongo/mongo.py
@@ -33,7 +33,7 @@ class MongoJSONEncoder(BaseJSONEncoder):
     .. versionadded:: 0.2
     """
     def default(self, obj):
-        # delegate rendering to base class method
+        # delegate rendering to mongo driver
         return json_util.default(obj)
 
 


### PR DESCRIPTION
The json_util provided by the pymongo driver covers more datatypes.
