### PR TITLE
typo

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,7 +4,7 @@
 Python REST API Framework
 =========================
 *Powered by Flask, MongoDB, Redis and good intentions Eve allows to
-effortlessly build and deploy highly customisable, fully featured RESTful Web
+effortlessly build and deploy highly customizable, fully featured RESTful Web
 Services*
 
 Eve is Simple


### PR DESCRIPTION
The correct is: "customizable" with Z
http://dictionary.reference.com/browse/customizable
With S doesn't exists: http://dictionary.reference.com/browse/customisable?s=t
