### PR TITLE
Modifies the GET behavior on list resources to adhere to HTTP standards

### DIFF
--- a/eve/methods/get.py
+++ b/eve/methods/get.py
@@ -19,6 +19,7 @@ from eve.auth import requires_auth
 from eve.utils import parse_request, document_etag, document_link, \
     collection_link, home_link, querydef, resource_uri, config, \
     debug_error_message
+import copy
 
 
 @ratelimit()
@@ -28,6 +29,12 @@ def get(resource):
     """Retrieves the resource documents that match the current request.
 
     :param resource: the name of the resource.
+
+    .. versionchanged:: 0.3
+       When If-Modified-Since header is present, either no documents (304) or
+       all documents (200) are sent per the HTTP spec. Original behavior can be
+       achieved with:
+           /resource?where={"updated":{"$gt":"if-modified-since-date"}}
 
     .. versionchanged:: 0.2
        Use the new ITEMS configuration setting.
@@ -66,9 +73,26 @@ def get(resource):
 
     documents = []
     response = {}
-    last_update = epoch()
-
+    etag = None
     req = parse_request(resource)
+
+    if req.if_modified_since:
+        # client has made this request before, has it changed?
+        preflight_req = copy.copy(req)
+        preflight_req.max_results = 1
+
+        cursor = app.data.find(resource, preflight_req)
+        if cursor.count() == 0:
+            # the if-modified-since conditional request returned no documents,
+            # we send back a 304 Not-Modified, which means that the client
+            # already has the up-to-date representation of the resultset.
+            status = 304
+            last_modified = None
+            return response, last_modified, etag, status
+
+    # continue processing the full request
+    last_update = epoch()
+    req.if_modified_since = None
     cursor = app.data.find(resource, req)
 
     for document in cursor:
@@ -89,38 +113,30 @@ def get(resource):
 
     _resolve_embedded_documents(resource, req, documents)
 
-    if req.if_modified_since and len(documents) == 0:
-        # the if-modified-since conditional request returned no documents, we
-        # send back a 304 Not-Modified, which means that the client already
-        # has the up-to-date representation of the resultset.
-        status = 304
-        last_modified = None
+    status = 200
+    last_modified = last_update if last_update > epoch() else None
+
+    # notify registered callback functions. Please note that, should the
+    # functions modify the documents, the last_modified and etag won't be
+    # updated to reflect the changes (they always reflect the documents
+    # state on the database.)
+
+    getattr(app, "on_fetch_resource")(resource, documents)
+    getattr(app, "on_fetch_resource_%s" % resource)(documents)
+
+    if config.DOMAIN[resource]['hateoas']:
+        response[config.ITEMS] = documents
+        response[config.LINKS] = _pagination_links(resource, req,
+                                                   cursor.count())
     else:
-        status = 200
-        last_modified = last_update if last_update > epoch() else None
+        response = documents
 
-        # notify registered callback functions. Please note that, should the
-        # functions modify the documents, the last_modified and etag won't be
-        # updated to reflect the changes (they always reflect the documents
-        # state on the database.)
+    # the 'extra' cursor field, if present, will be added to the response.
+    # Can be used by Eve extensions to add extra, custom data to any
+    # response.
+    if hasattr(cursor, 'extra'):
+        getattr(cursor, 'extra')(response)
 
-        getattr(app, "on_fetch_resource")(resource, documents)
-        getattr(app, "on_fetch_resource_%s" % resource)(documents)
-
-        if config.DOMAIN[resource]['hateoas']:
-            response[config.ITEMS] = documents
-            response[config.LINKS] = _pagination_links(resource, req,
-                                                       cursor.count())
-        else:
-            response = documents
-
-        # the 'extra' cursor field, if present, will be added to the response.
-        # Can be used by Eve extensions to add extra, custom data to any
-        # response.
-        if hasattr(cursor, 'extra'):
-            getattr(cursor, 'extra')(response)
-
-    etag = None
     return response, last_modified, etag, status
 
 


### PR DESCRIPTION
Modifies the GET behavior on list resources to adhere to HTTP standards when the If-Modified-Since header is present

Previously, eve would return a partial document list if only some documents had been modified since the time present in an If-Modified-Since header. However, the correct response should be to return all documents (200) or no documents (304) only. Returning a partial set is not an option. See issue #190 for more information.

To implement this fix, I do a preflight query leaving req.if_modified_since in place with a limit of 1 sorted by date. (This query effectively answers the question "has anything been modified since this date?") By placing this check in methods/get.py, the same 304 response behavior will exist regardless of data layer.

I would prefer, however, to entirely remove the code in io/mongo/mongo.py that checks for req.if_modified_since since I'm not sure if other HTTP verbs/methods rely on req.if_modified_since. But to do so, I'd have to modify the where argument of the request, and since the query arguments aren't parsed before the data layer and since multiple where argument formats are allowed, this would have been difficult or at the very least redundant. (Redundant if I parse the where clause, modified it, re-stringify and then the data layer would once again re-parse it.)

On that note, I'd suggest moving argument parsing out of the data layer and into utils.py/parse_request(). By placing argument parsing in the data layer as currently implemented, the possibility exists for data layers to interpret arguments differently. I imagine the preferred response is to support and enforce the same query syntax regardless of the data layer. Issue #194 has been opened to relay this request.
