### PR TITLE
Make Access-Control-Max-Age a configurable value

### DIFF
--- a/eve/default_settings.py
+++ b/eve/default_settings.py
@@ -68,7 +68,7 @@ CACHE_EXPIRES = 0
 ITEM_CACHE_CONTROL = ''
 X_DOMAINS = None                # CORS disabled by default.
 X_HEADERS = None                # CORS disabled by default.
-MAX_AGE = 21600                 # Access-Control-Max-Age when CORS is enabled
+X_MAX_AGE = 21600               # Access-Control-Max-Age when CORS is enabled
 HATEOAS = True                  # HATEOAS enabled by default.
 IF_MATCH = True                 # IF_MATCH (ETag match) enabled by default.
 

--- a/eve/render.py
+++ b/eve/render.py
@@ -168,7 +168,7 @@ def _prepare_response(resource, dct, last_modified=None, etag=None,
         resp.headers.add('Access-Control-Allow-Origin', ', '.join(domains))
         resp.headers.add('Access-Control-Allow-Headers', ', '.join(headers))
         resp.headers.add('Access-Control-Allow-Methods', methods)
-        resp.headers.add('Access-Control-Allow-Max-Age', config.MAX_AGE)
+        resp.headers.add('Access-Control-Allow-Max-Age', config.X_MAX_AGE)
 
     # Rate-Limiting
     limit = get_rate_limit()

--- a/eve/tests/renders.py
+++ b/eve/tests/renders.py
@@ -110,7 +110,7 @@ class TestRenders(TestBase):
         self.assertEqual(r.headers['Access-Control-Allow-Max-Age'],
                          '21600')
 
-        self.app.config['MAX_AGE'] = 2000
+        self.app.config['X_MAX_AGE'] = 2000
         r = self.test_client.get('/', headers=[('Origin',
                                                 'http://example.com')])
         self.assertEqual(r.headers['Access-Control-Allow-Max-Age'],


### PR DESCRIPTION
When using eve with rapidly changing data, the 21600 default of access-control-max-age for cors requests becomes too long, so made the max_age field configurable (decided it was time I didn't just complain about the code, but actually try to fix some things). Added a simple test for the default case, and with a changed value.
