### PR TITLE
#493 definition['type'] throws exception

### DIFF
--- a/eve/flaskapp.py
+++ b/eve/flaskapp.py
@@ -490,7 +490,7 @@ class Eve(Flask, Events):
 
         # list of all media fields for the resource
         settings['_media'] = [field for field, definition in schema.items() if
-                              definition['type'] == 'media']
+                              definition.get('type') == 'media']
 
         if settings['_media'] and not self.media:
             raise ConfigException('A media storage class of type '


### PR DESCRIPTION
definition['type'] == 'media', since this seems to be a check if media fields are present, I think the get() method should be better suitable since it throws no KeyError exception. 
I had some problems with a 
nested key
'items': {'type': 'list', 'schema': {'type': 'dict', 'schema': '{another_dict}'}
