### PR TITLE
Modify lookup

### DIFF
--- a/eve/io/mongo/mongo.py
+++ b/eve/io/mongo/mongo.py
@@ -151,14 +151,17 @@ class Mongo(DataLayer):
                         'Unable to parse `where` clause'
                     ))
 
+        bad_filter = validate_filters(spec, resource)
+        if bad_filter:
+            abort(400, bad_filter)
+
+        # is this safe? Can the value of sub_resource_lookup ever be provided
+        # by a client, or can we rely on it to only be set by lookup callbacks
+        # and filters configured in the settings file?
         if sub_resource_lookup:
             spec.update(sub_resource_lookup)
 
         spec = self._mongotize(spec, resource)
-
-        bad_filter = validate_filters(spec, resource)
-        if bad_filter:
-            abort(400, bad_filter)
 
         client_projection = self._client_projection(req)
 

--- a/eve/methods/get.py
+++ b/eve/methods/get.py
@@ -85,6 +85,10 @@ def get(resource, lookup):
     etag = None
     req = parse_request(resource)
 
+    event_name = 'on_pre_GET_%s_lookup' % (resource)
+    updated_lookup = getattr(app, event_name)(lookup)
+    lookup = updated_lookup or lookup
+
     if req.if_modified_since:
         # client has made this request before, has it changed?
         preflight_req = copy.copy(req)


### PR DESCRIPTION
I needed this feature. Use case is sending messages between 2 users, I apply a lookup to restrict a GET to the `messages` endpoint to only return those where the authenticated user is either the sender or recipient.

As noted in the commit message, the feature is incomplete. Are you happy with the approach? If so, I'll update the other HTTP methods that use a lookup and add tests. 

Please see the notes in the code. I'm assuming the `sub_resource_lookup` field is only ever provided by Eve, and can never be insecure data supplied by clients. Please confirm that's a valid assumption.

Thanks
