### PR TITLE
Return a 400 response on pymongo DuplicateKeyError

### DIFF
--- a/eve/io/mongo/mongo.py
+++ b/eve/io/mongo/mongo.py
@@ -331,6 +331,10 @@ class Mongo(DataLayer):
         try:
             self.driver.db[datasource].update(filter_, {"$set": updates},
                                               **self._wc(resource))
+        except pymongo.errors.DuplicateKeyError as e:
+            abort(400, description=debug_error_message(
+                'pymongo.errors.DuplicateKeyError: %s' % e
+            ))
         except pymongo.errors.OperationFailure as e:
             # see comment in :func:`insert()`.
             abort(500, description=debug_error_message(


### PR DESCRIPTION
Note: This is a cleaned up version of #268 that isn't directly on develop.

Duplicate key errors were returning 500s. Now they return a more precise 400 instead (409 would be the most accurate, but I see you're reraising errors as 400s - search for "# consider all other exceptions as Bad Requests". Perhaps this is to avoid leaking too much information?)

Re tests: I'd normally test this by using `mock` to mock the return value of the call to `self.driver.db[datasource].update` to raise a `pymongo.errors.DuplicateKeyError`, but you don't seem to be using mock. I can't see any existing tests for the update method... is it OK if I introduce mock as a dependency? If not, how would you like this testing?
