### PR TITLE
Added on_pre_GET_<resource>_lookup event.

### DIFF
--- a/eve/io/mongo/mongo.py
+++ b/eve/io/mongo/mongo.py
@@ -151,14 +151,14 @@ class Mongo(DataLayer):
                         'Unable to parse `where` clause'
                     ))
 
+        bad_filter = validate_filters(spec, resource)
+        if bad_filter:
+            abort(400, bad_filter)
+
         if sub_resource_lookup:
             spec.update(sub_resource_lookup)
 
         spec = self._mongotize(spec, resource)
-
-        bad_filter = validate_filters(spec, resource)
-        if bad_filter:
-            abort(400, bad_filter)
 
         client_projection = self._client_projection(req)
 

--- a/eve/methods/get.py
+++ b/eve/methods/get.py
@@ -85,6 +85,9 @@ def get(resource, lookup):
     etag = None
     req = parse_request(resource)
 
+    event_name = 'on_pre_GET_%s_lookup' % (resource)
+    lookup = getattr(app, event_name)(lookup) or lookup
+
     if req.if_modified_since:
         # client has made this request before, has it changed?
         preflight_req = copy.copy(req)


### PR DESCRIPTION
This feature allows to programmatically alter the lookup parameter passed to the data
layer that will be used to find documents. The contraint returned by a lookup event
is not restricted any `allowed_filters` setting since it is considered trusted. This
allows the API to be restricted in terms of what filters clients can supply, while
still providing full flexibility to developers.

This feature is incomplete. If discussions are positive, it will be completed and
tests added.
