### PR TITLE
Fix minor typo in an error message

### DIFF
--- a/eve/flaskapp.py
+++ b/eve/flaskapp.py
@@ -265,7 +265,7 @@ class Eve(Flask, Events):
            'PATCH' in settings['item_methods']:
             if len(settings['schema']) == 0:
                 raise ConfigException('A resource schema must be provided '
-                                      'when POST or PATCH methods are allowed'
+                                      'when POST or PATCH methods are allowed '
                                       'for a resource [%s].' % resource)
 
         self.validate_roles('allowed_roles', settings, resource)


### PR DESCRIPTION
Fixes missing whitespace between words:

> ConfigException: A resource schema must be provided when POST or PATCH methods are **allowedfor** a resource [waves].
