### PR TITLE
Iss302

### DIFF
--- a/eve/methods/common.py
+++ b/eve/methods/common.py
@@ -424,7 +424,8 @@ def pre_event(f):
         method = request_method()
         event_name = 'on_pre_' + method
         resource = args[0] if args else None
-
+        gh_params = ()
+        rh_params = ()
         if method in ('GET', 'PATCH', 'DELETE', 'PUT'):
             gh_params = (resource, request, kwargs)
             rh_params = (request, kwargs)

--- a/eve/tests/methods/get.py
+++ b/eve/tests/methods/get.py
@@ -834,8 +834,8 @@ class TestHead(TestBase):
         self.assertHead(self.item_id_url)
 
     def assertHead(self, url):
-        h = self.test_client.head('/')
-        r = self.test_client.get('/')
+        h = self.test_client.head(url)
+        r = self.test_client.get(url)
         self.assertTrue(not h.data)
         self.assertEqual(r.headers, h.headers)
 


### PR DESCRIPTION
Fix bug from issue #302 where HEAD calls on resources or items causes a server error. Also updated the assertHead call in tests to use the passed url instead of always `'/'`
