### PR TITLE
Pass the request, not the resource to on_pre_POST_<resource> callbacks

### DIFF
--- a/eve/methods/common.py
+++ b/eve/methods/common.py
@@ -432,7 +432,7 @@ def pre_event(f):
         elif method in ('POST'):
             # POST hook does not support the kwargs argument
             gh_params = (resource, request)
-            rh_params = (resource,)
+            rh_params = (request,)
 
         # general hook
         getattr(app, event_name)(*gh_params)


### PR DESCRIPTION
The resource was incorrectly being passed to on_pre_POST_<resource> callbacks. This PR fixes it to pass the request object instead.
