### PR TITLE
Add test for post with optional custom payload

### DIFF
--- a/eve/tests/methods/post.py
+++ b/eve/tests/methods/post.py
@@ -6,6 +6,7 @@ from eve.tests.test_settings import MONGO_DBNAME
 
 from eve import STATUS_OK, LAST_UPDATED, ID_FIELD, DATE_CREATED, ISSUES, \
     STATUS, ETAG
+from eve.methods.post import post
 
 
 class TestPost(TestBase):
@@ -355,6 +356,13 @@ class TestPost(TestBase):
         r, status = self.get(
             self.empty_resource, '', r[self.app.config['ID_FIELD']])
         self.assertEqual(etag, r[self.app.config['ETAG']])
+
+    def test_post_alternative_payload(self):
+        payl = {"ref": "5432112345678901234567890", "role": ["agent"]}
+        with self.app.test_request_context(self.known_resource_url):
+            r, _, _, status = post(self.known_resource, payl=payl)
+        self.assert201(status)
+        self.assertPostResponse(r)
 
     def perform_post(self, data, valid_items=[0]):
         r, status = self.post(self.known_resource_url, data=data)


### PR DESCRIPTION
Support for calling post with optional custom payload was introduced in
8d0695f.
