### PR TITLE
PAGINATION_DEFAULT is applied to version=all/diff, but pagination is not supported

### DIFF
--- a/eve/methods/get.py
+++ b/eve/methods/get.py
@@ -234,7 +234,9 @@ def getitem(resource, **lookup):
         return {}, last_modified, document.get(config.ETAG), 304
 
     if version == 'all' or version == 'diffs':
-        # TODO: support pagination?
+        # TODO: support pagination? For now, no result limit.
+        if hasattr(req, 'max_results'):
+            del req.max_results
 
         # find all versions
         lookup[versioned_id_field()] = lookup[app.config['ID_FIELD']]


### PR DESCRIPTION
If the number of versions of a document > `PAGINATION_DEFAULT`, then the result set is truncated to that count. I feel certain this is not by design, because A. it leaves no way to fetch the remaining versions, and B. the returned versions are the oldest ones, where if this was intentional, certainly the newest ones would make sense.

Instead, unless and until pagination of `version=all/diffs` results is supported, _all_ versions should be returned. Hence, this PR.
