### PR TITLE
Gender nutralise

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -36,7 +36,7 @@ Live demo
 Check out the `live demo`_. If using a browser you will get XML back. For JSON
 in the browser, you might want to install Postman_ or similar extension and
 then set the ``Accept`` request header to ``application/json``. If you are
-a CLI guy (and you should), ``curl`` is your friend. The `source code`_ will
+a CLI user (and you should), ``curl`` is your friend. The `source code`_ will
 show you how easy it is to run an API with Eve. You will also find `usage
 examples`_ for all common use cases (GET, POST, PATCH, DELETE and more). There
 is also a simple `client app`_ available.


### PR DESCRIPTION
Guy is often used when meaning men and woman, but sometimes it only means men. So, to avoid ambiguity, lets switch to something that is clearly gender neutral.
