### PR TITLE
add test case for 403 error on PUT

### DIFF
--- a/eve/tests/methods/put.py
+++ b/eve/tests/methods/put.py
@@ -17,6 +17,11 @@ class TestPut(TestBase):
         _, status = self.put(self.readonly_id_url, data={})
         self.assert405(status)
 
+    def test_known_id(self):
+        _, status = self.put(self.item_id_url,
+                             data={'key1': 'value1'})
+        self.assert200(status)
+
     def test_unknown_id(self):
         _, status = self.put(self.unknown_item_id_url,
                              data={'key1': 'value1'})


### PR DESCRIPTION
Hi, i receive a `403` error by Eve as response of a `PUT` request which looks correct, and where the settings should apparently allow it. I tried to replicate the use case with the Eve test suite, and indeed my test is failing there. I am not an expert of the test suite, i collected this quickly, so this could be a false positive.

This pull request is not intended to be merged, but just to show the failing test
