### PR TITLE
Standardize inserts (bulk or not) to comply with RESTful status behavior

### DIFF
--- a/docs/features.rst
+++ b/docs/features.rst
@@ -513,22 +513,25 @@ The response will be a list itself, with the state of each document:
 
 .. code-block:: javascript
 
-    [
-        {
-            "_status": "OK",
-            "_updated": "Thu, 22 Nov 2012 15:22:27 GMT",
-            "_id": "50ae43339fa12500024def5b",
-            "_etag": "749093d334ebd05cf7f2b7dbfb7868605578db2c"
-            "_links": {"self": {"href": "eve-demo.herokuapp.com/people/50ae43339fa12500024def5b", "title": "person"}}
-        },
-        {
-            "_status": "OK",
-            "_updated": "Thu, 22 Nov 2012 15:22:27 GMT",
-            "_id": "50ae43339fa12500024def5c",
-            "_etag": "62d356f623c7d9dc864ffa5facc47dced4ba6907"
-            "_links": {"self": {"href": "eve-demo.herokuapp.com/people/50ae43339fa12500024def5c", "title": "person"}}
-        }
-    ]
+    {
+        "_status": "OK",
+        "_items": [
+            {
+                "_status": "OK",
+                "_updated": "Thu, 22 Nov 2012 15:22:27 GMT",
+                "_id": "50ae43339fa12500024def5b",
+                "_etag": "749093d334ebd05cf7f2b7dbfb7868605578db2c"
+                "_links": {"self": {"href": "eve-demo.herokuapp.com/people/50ae43339fa12500024def5b", "title": "person"}}
+            },
+            {
+                "_status": "OK",
+                "_updated": "Thu, 22 Nov 2012 15:22:27 GMT",
+                "_id": "50ae43339fa12500024def5c",
+                "_etag": "62d356f623c7d9dc864ffa5facc47dced4ba6907"
+                "_links": {"self": {"href": "eve-demo.herokuapp.com/people/50ae43339fa12500024def5c", "title": "person"}}
+            }
+        ]
+    }
 
 When multiple documents are submitted the API takes advantage of MongoDB *bulk
 insert* capabilities which means that not only there's just one single request
@@ -552,34 +555,26 @@ request:
 
 .. code-block:: javascript
 
-    [
-        {
-            "_status": "ERR",
-            "_issues": {"lastname": "value 'clinton' not unique"}
-        },
-        {
-            "_status": "OK",
-            "_updated": "Thu, 22 Nov 2012 15:29:08 GMT",
-            "_id": "50ae44c49fa12500024def5d",
-            "_links": {"self": {"href": "eve-demo.herokuapp.com/people/50ae44c49fa12500024def5d", "title": "person"}}
-        }
+    {
+        "_status": "ERR",
+        "_error": "Some documents contains errors",
+        "_items": [
+            {
+                "_status": "ERR",
+                "_issues": {"lastname": "value 'clinton' not unique"}
+            },
+            {
+                "_status": "OK",
+            }
+        ]
     ]
 
-In the example above, the first document did not validate and was rejected,
-while the second was successfully created. The API maintainer has complete
-control on data validation. Optionally, you can decide to allow for unknown
-fields to be inserted/updated on one or more endpoints. For more information
-see :ref:`validation`.
+In the example above, the first document did not validate so the whole request
+has been rejected. For more information see :ref:`validation`.
 
-.. admonition:: Please Note
-
-    Eventual validation errors on one or more document won't prevent the
-    insertion of valid documents. The response status code will be ``201
-    Created`` if *at least one document* passed validation and has actually
-    been stored. If no document passed validation the status code will be ``200
-    OK``, meaning that the request was accepted and processed. It is still
-    client's responsability to parse the response payload and make sure that
-    all documents passed validation.
+In all cases, when all documents passed validation and where inserted correctly,
+the response status is ``201 Created``. If any document fail the validation, the
+response status is ``400 Bad Request``.
 
 Extensible Data Validation
 --------------------------

--- a/eve/methods/post.py
+++ b/eve/methods/post.py
@@ -120,7 +120,8 @@ def post(resource, payl=None):
     schema = resource_def['schema']
     validator = app.validator(schema, resource)
     documents = []
-    issues = []
+    results = []
+    failures = 0
 
     if config.BANDWIDTH_SAVER is True:
         embedded_fields = []
@@ -161,12 +162,28 @@ def post(resource, payl=None):
             # the client as if it was a validation issue
             doc_issues['exception'] = str(e)
 
-        issues.append(doc_issues)
 
-        if len(doc_issues) == 0:
-            documents.append(document)
+        if len(doc_issues):
+            document = {
+                config.STATUS: config.STATUS_ERR,
+                config.ISSUES: doc_issues,
+            }
+            failures += 1
 
-    if len(documents):
+        documents.append(document)
+
+    if failures:
+        # If at least one document got issues, the whole request fails and a
+        # ``400 Bad Request`` status is return.
+        for document in documents:
+            if config.STATUS in document \
+               and document[config.STATUS] == config.STATUS_ERR:
+                results.append(document)
+            else:
+                results.append({config.STATUS: config.STATUS_OK})
+
+        return_code = 400
+    else:
         # notify callbacks
         getattr(app, "on_insert")(resource, documents)
         getattr(app, "on_insert_%s" % resource)(documents)
@@ -181,6 +198,18 @@ def post(resource, payl=None):
             document[config.ID_FIELD] = \
                 document.get(config.ID_FIELD, ids.pop(0))
 
+            # build the full response document
+            result = document
+            build_response_document(
+                result, resource, embedded_fields, document)
+
+            # add extra write meta data
+            result[config.STATUS] = config.STATUS_OK
+
+            # limit what actually gets sent to minimize bandwidth usage
+            result = marshal_write_response(result, resource)
+            results.append(result)
+
         # insert versioning docs
         insert_versioning_documents(resource, documents)
 
@@ -190,46 +219,20 @@ def post(resource, payl=None):
         # request was received and accepted; at least one document passed
         # validation and was accepted for insertion.
 
-        # from the docs:
-        # Eventual validation errors on one or more document won't prevent the
-        # insertion of valid documents. The response status code will be ``201
-        # Created`` if *at least one document* passed validation and has
-        # actually been stored.
         return_code = 201
+
+    if len(results) == 1:
+        response = results.pop(0)
     else:
-        # request was received and accepted; no document passed validation
-        # though.
+        response = {
+            config.STATUS: config.STATUS_ERR if failures else config.STATUS_OK,
+            config.ITEMS: results,
+        }
 
-        # from the docs:
-        # If no document passed validation the status code will be ``200 OK``,
-        # meaning that the request was accepted and processed. It is still
-        # client's responsibility to parse the response payload and make sure
-        # that all documents passed validation.
-        return_code = 200
-
-    # build response payload
-    response = []
-    for doc_issues in issues:
-        if len(doc_issues):
-            document = {}
-            document[config.STATUS] = config.STATUS_ERR
-            document[config.ISSUES] = doc_issues
-        else:
-            document = documents.pop(0)
-
-            # build the full response document
-            build_response_document(
-                document, resource, embedded_fields, document)
-
-            # add extra write meta data
-            document[config.STATUS] = config.STATUS_OK
-
-            # limit what actually gets sent to minimize bandwidth usage
-            document = marshal_write_response(document, resource)
-
-        response.append(document)
-
-    if len(response) == 1:
-        response = response.pop(0)
+    if failures:
+        response[config.ERROR] = {
+            "code": return_code,
+            "message": "Insertion failure: %d document(s) contain(s) error(s)" % failures,
+        }
 
     return response, None, None, return_code

--- a/eve/tests/__init__.py
+++ b/eve/tests/__init__.py
@@ -133,7 +133,10 @@ class TestMinimal(unittest.TestCase):
         return self.parse_response(r)
 
     def parse_response(self, r):
-        v = json.loads(r.get_data()) if r.status_code in (200, 201) else None
+        try:
+            v = json.loads(r.get_data())
+        except json.JSONDecodeError:
+            v = None
         return v, r.status_code
 
     def assertValidationError(self, response, matches):

--- a/eve/tests/auth.py
+++ b/eve/tests/auth.py
@@ -91,7 +91,7 @@ class TestBasicAuth(TestBase):
         r = self.test_client.post(self.known_resource_url,
                                   data=json.dumps({"k": "value"}),
                                   headers=self.valid_auth)
-        self.assert200(r.status_code)
+        self.assert400(r.status_code)
         r = self.test_client.delete(self.known_resource_url,
                                     headers=self.valid_auth)
         self.assert200(r.status_code)

--- a/eve/tests/methods/post.py
+++ b/eve/tests/methods/post.py
@@ -24,11 +24,11 @@ class TestPost(TestBase):
 
     def test_validation_error(self):
         r, status = self.post(self.known_resource_url, data={"ref": "123"})
-        self.assert200(status)
+        self.assert400(status)
         self.assertValidationError(r, {'ref': 'min length is 25'})
 
         r, status = self.post(self.known_resource_url, data={"prog": 123})
-        self.assert200(status)
+        self.assert400(status)
         self.assertValidationError(r, {'ref': 'required'})
 
     def test_post_empty_resource(self):
@@ -140,23 +140,27 @@ class TestPost(TestBase):
             {"ref": self.item_ref},
             {"ref": "9234567890123456789054321", "tid": "12345678"},
         ]
-        r = self.perform_post(data, [0, 2])
+        r, status = self.post(self.known_resource_url, data=data)
+        self.assert400(status)
+        results = r['_items']
 
-        self.assertValidationError(r[1], {'ref': 'required'})
-        self.assertValidationError(r[3], {'ref': 'unique'})
-        self.assertValidationError(r[4], {'tid': 'ObjectId'})
+        self.assertEqual(results[0]['_status'], 'OK')
+        self.assertEqual(results[2]['_status'], 'OK')
 
-        item_id = r[0][ID_FIELD]
-        db_value = self.compare_post_with_get(item_id, 'ref')
-        self.assertTrue(db_value == data[0]['ref'])
+        self.assertValidationError(results[1], {'ref': 'required'})
+        self.assertValidationError(results[3], {'ref': 'unique'})
+        self.assertValidationError(results[4], {'tid': 'ObjectId'})
 
-        item_id = r[2][ID_FIELD]
-        db_value = self.compare_post_with_get(item_id, ['ref', 'role'])
-        self.assertTrue(db_value[0] == data[2]['ref'])
-        self.assertTrue(db_value[1] == data[2]['role'])
+        self.assertNotIn(ID_FIELD, results[0])
+        self.assertNotIn(ID_FIELD, results[2])
 
         # items on which validation failed should not be inserted into the db
         _, status = self.get(self.known_resource_url, 'where=prog==7')
+        self.assert404(status)
+
+        # valid items part of a request containing invalid document should not
+        # be inserted into the db
+        _, status = self.get(self.known_resource_url, 'where=ref==9234567890123456789054321')
         self.assert404(status)
 
     def test_post_x_www_form_urlencoded(self):
@@ -172,7 +176,7 @@ class TestPost(TestBase):
     def test_post_referential_integrity(self):
         data = {"person": self.unknown_item_id}
         r, status = self.post('/invoices/', data=data)
-        self.assert200(status)
+        self.assert400(status)
         expected = ("value '%s' must exist in resource '%s', field '%s'" %
                     (self.unknown_item_id, 'contacts',
                      self.app.config['ID_FIELD']))
@@ -187,7 +191,7 @@ class TestPost(TestBase):
         del(self.domain['contacts']['schema']['ref']['required'])
         data = {"unknown": "unknown"}
         r, status = self.post(self.known_resource_url, data=data)
-        self.assert200(status)
+        self.assert400(status)
         self.assertValidationError(r, {'unknown': 'unknown'})
         self.app.config['DOMAIN'][self.known_resource]['allow_unknown'] = True
         r, status = self.post(self.known_resource_url, data=data)
@@ -280,13 +284,13 @@ class TestPost(TestBase):
     def test_custom_issues(self):
         self.app.config['ISSUES'] = 'errors'
         r, status = self.post(self.known_resource_url, data={"ref": "123"})
-        self.assert200(status)
+        self.assert400(status)
         self.assertTrue('errors' in r and ISSUES not in r)
 
     def test_custom_status(self):
         self.app.config['STATUS'] = 'report'
         r, status = self.post(self.known_resource_url, data={"ref": "123"})
-        self.assert200(status)
+        self.assert400(status)
         self.assertTrue('report' in r and STATUS not in r)
 
     def test_custom_etag_update_date(self):
@@ -394,7 +398,7 @@ class TestPost(TestBase):
         test_value = 'a random value'
         data = {test_field: test_value}
         r, status = self.post(self.known_resource_url, data=data)
-        self.assert200(status)
+        self.assert400(status)
         # this will pass as value matches 'default' setting.
         test_value = 'default'
         data = {test_field: test_value}
@@ -415,10 +419,13 @@ class TestPost(TestBase):
         self.assertTrue(db_value[1] == item_etag)
 
     def assertPostResponse(self, response, valid_items=[0], id_field=ID_FIELD):
-        if isinstance(response, dict):
-            response = [response]
+        if '_items' in response:
+            results = response['_items']
+        else:
+            results = [response]
+
         for i in valid_items:
-            item = response[i]
+            item = results[i]
             self.assertTrue(STATUS in item)
             self.assertTrue(STATUS_OK in item[STATUS])
             self.assertFalse(ISSUES in item)

--- a/eve/tests/versioning.py
+++ b/eve/tests/versioning.py
@@ -491,14 +491,14 @@ class TestCompleteVersioning(TestNormalVersioning):
         self.item_change[self.version_field] = '1'
         r, status = self.post(
             self.known_resource_url, data=self.item_change)
-        self.assert200(status)
+        self.assert400(status)
         self.assertValidationError(r, {self.version_field: 'unknown field'})
 
         # set _latest_version
         self.item_change[self.latest_version_field] = '1'
         r, status = self.post(
             self.known_resource_url, data=self.item_change)
-        self.assert200(status)
+        self.assert400(status)
         self.assertValidationError(
             r, {self.latest_version_field: 'unknown field'})
 
@@ -506,7 +506,7 @@ class TestCompleteVersioning(TestNormalVersioning):
         self.item_change[self.document_id_field] = '1'
         r, status = self.post(
             self.known_resource_url, data=self.item_change)
-        self.assert200(status)
+        self.assert400(status)
         self.assertValidationError(
             r, {self.document_id_field: 'unknown field'})
 
@@ -516,7 +516,7 @@ class TestCompleteVersioning(TestNormalVersioning):
         """
         data = {"person": self.unknown_item_id}
         r, status = self.post('/invoices/', data=data)
-        self.assert200(status)
+        self.assert400(status)
         expected = ("value '%s' must exist in resource '%s', field '%s'" %
                     (self.unknown_item_id, 'contacts',
                      self.app.config['ID_FIELD']))
@@ -591,25 +591,25 @@ class TestDataRelationVersionNotVersioned(TestNormalVersioning):
         # must be a dict
         data = {"person": self.item_id}
         r, status = self.post('/invoices/', data=data)
-        self.assert200(status)
+        self.assert400(status)
         self.assertValidationError(r, {'person': 'must be of dict type'})
 
         # must have _id
         data = {"person": {value_field: self.item_id}}
         r, status = self.post('/invoices/', data=data)
-        self.assert200(status)
+        self.assert400(status)
         self.assertValidationError(r, {'person': validation_error_format})
 
         # must have _version
         data = {"person": {version_field: 1}}
         r, status = self.post('/invoices/', data=data)
-        self.assert200(status)
+        self.assert400(status)
         self.assertValidationError(r, {'person': validation_error_format})
 
         # bad id format
         data = {"person": {value_field: 'bad', version_field: 1}}
         r, status = self.post('/invoices/', data=data)
-        self.assert200(status)
+        self.assert400(status)
         self.assertValidationError(
             r, {'person': {
                 value_field: "value 'bad' cannot be converted to a ObjectId"}})
@@ -618,7 +618,7 @@ class TestDataRelationVersionNotVersioned(TestNormalVersioning):
         data = {"person": {
             value_field: self.unknown_item_id, version_field: 1}}
         r, status = self.post('/invoices/', data=data)
-        self.assert200(status)
+        self.assert400(status)
         self.assertValidationError(
             r, {'person': "value '%s' must exist in "
                 "resource '%s', field '%s' at version '%s'." %
@@ -627,7 +627,7 @@ class TestDataRelationVersionNotVersioned(TestNormalVersioning):
         # version doesn't exist
         data = {"person": {value_field: self.item_id, version_field: 2}}
         r, status = self.post('/invoices/', data=data)
-        self.assert200(status)
+        self.assert400(status)
         self.assertValidationError(
             r, {'person': "value '%s' must exist in "
                 "resource '%s', field '%s' at version '%s'." %
@@ -695,7 +695,7 @@ class TestDataRelationVersionVersioned(TestNormalVersioning):
         # try saving a field from the first version against version 2
         data = {"person": {'ref': self.item['ref'], self.version_field: 2}}
         r, status = self.post('/invoices/', data=data)
-        self.assert200(status)
+        self.assert400(status)
         self.assertValidationError(
             r, {'person': "value '%s' must exist in "
                 "resource '%s', field '%s' at version '%s'." %


### PR DESCRIPTION
For bulk and non-bulk inserts, response status now always either 201 when everything was ok or 400 when something went wrong. For bulk inserts, if at least one document doesn't validate, the whole request is rejected, and none of the documents are inserted into the database.

Additionnaly, this commit adopts the same response format as collections: responses are always a dict with a `_status` field at its root and an eventual `_error` object if `_status` is `ERR` to comply with #366.
Documents status are stored in the `_items` field.

Example:

``` json
{
    "_status": "ERR",
    "_error": {
        "code": 400,
        "message": "Insertion failure: 1 document(s) contain(s) error(s)"
    },
    "_items": [
        {
            "_status": "OK"
        },
        {
            "_issues": {
                "email": "required field"
            },
            "_status": "ERR"
        }
    ]
}
```

This unified response format will ease client implementation.
