### PR TITLE
fix(config): make it possible to init app with empty domain

### DIFF
--- a/eve/flaskapp.py
+++ b/eve/flaskapp.py
@@ -215,8 +215,6 @@ class Eve(Flask, Events):
             raise ConfigException('DOMAIN dictionary missing or wrong.')
         if not isinstance(domain, dict):
             raise ConfigException('DOMAIN must be a dict.')
-        if len(domain) == 0:
-            raise ConfigException('DOMAIN must contain at least one resource.')
 
     def validate_config(self):
         """ Makes sure that REST methods expressed in the configuration

--- a/eve/tests/config.py
+++ b/eve/tests/config.py
@@ -89,7 +89,7 @@ class TestConfig(TestBase):
         self.assertValidateConfigFailure('must be a dict')
 
         self.app.config['DOMAIN'] = {}
-        self.assertValidateConfigFailure('must contain at least one')
+        self.assertValidateConfigSuccess()
 
     def test_validate_resource_methods(self):
         self.app.config['RESOURCE_METHODS'] = ['PUT', 'GET', 'DELETE', 'POST']


### PR DESCRIPTION
hi - now you can use `app.register_resource` to define your domain but if you start app without any resource predefined you get an exception. i think it should not while you can define resources later
