### PR TITLE
Fix ?version=all/diffs bug preventing full response

### DIFF
--- a/eve/methods/get.py
+++ b/eve/methods/get.py
@@ -250,6 +250,7 @@ def getitem(resource, **lookup):
         if version == 'diffs' or req.sort is None:
             # default sort for 'all', required sort for 'diffs'
             req.sort = '[("%s", 1)]' % config.VERSION
+        req.if_modified_since = None  # we always want the full history here
         cursor = app.data.find(resource + config.VERSIONS, req, lookup)
 
         # build all versions


### PR DESCRIPTION
Previously, `?version=all` or `?version=diffs` would only return that last document version immediately following a PUT. This was not the intended output.
