### PR TITLE
Fix bug in TestMinimal

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -10,6 +10,7 @@ Patches and Contributions
 `````````````````````````
 
 - Alexander Hendorf
+- Andreas Røssland
 - Ben Demaree
 - Bryan Cattle
 - boosh

--- a/eve/tests/__init__.py
+++ b/eve/tests/__init__.py
@@ -113,17 +113,23 @@ class TestMinimal(unittest.TestCase):
         r = self.test_client.get(request)
         return self.parse_response(r)
 
-    def post(self, url, data, headers=[], content_type='application/json'):
+    def post(self, url, data, headers=None, content_type='application/json'):
+        if headers is None:
+            headers = []
         headers.append(('Content-Type', content_type))
         r = self.test_client.post(url, data=json.dumps(data), headers=headers)
         return self.parse_response(r)
 
-    def put(self, url, data, headers=[]):
+    def put(self, url, data, headers=None):
+        if headers is None:
+            headers = []
         headers.append(('Content-Type', 'application/json'))
         r = self.test_client.put(url, data=json.dumps(data), headers=headers)
         return self.parse_response(r)
 
-    def patch(self, url, data, headers=[]):
+    def patch(self, url, data, headers=None):
+        if headers is None:
+            headers = []
         headers.append(('Content-Type', 'application/json'))
         r = self.test_client.patch(url, data=json.dumps(data), headers=headers)
         return self.parse_response(r)


### PR DESCRIPTION
The functions post, put and patch use a mutable argument as default.
This is a common Python pitfall, causing the headers list to grow each
the same function is called.
