### PR TITLE
Fix server crash in case of invalid "where" syntax

### DIFF
--- a/eve/io/mongo/parser.py
+++ b/eve/io/mongo/parser.py
@@ -26,8 +26,10 @@ def parse(expression):
     v = MongoVisitor()
     try:
         v.visit(ast.parse(expression))
-    except SyntaxError:
-        raise ParseError(), None, sys.exc_info()[2]
+    except SyntaxError as e:
+        e = ParseError(e)
+        e.__traceback__ = sys.exc_info()[2]
+        raise e
     return v.mongo_query
 
 


### PR DESCRIPTION
Wrap SyntaxError to ParseError in mongo.parser to prevent from sever
crash in case of invalid `where` syntax

Way to reproduce the crash:

```
GET /endpoint?where={"field":"value"
```
