### PR TITLE
Embedding in subdocuments

### DIFF
--- a/docs/features.rst
+++ b/docs/features.rst
@@ -810,11 +810,14 @@ documents will be embedded by default.
 
 Limitations
 ~~~~~~~~~~~
-Currenly we only support a single layer of embedding, i.e.
-``/emails?embedded={"author": 1}`` but *not*
-``/emails?embedded={"author.friends": 1}``. This feature is about serialization
-on GET requests. There's no support for POST, PUT or PATCH of embedded
-documents.
+Currently we support embedding of documents by references located in any
+subdocuments (nested dicts and lists). For example, a query
+``/invoices?/embedded={"user.friends":1}`` will return a document with ``user``
+and all his ``friends`` embedded, but only if ``user`` is a subdocument and
+``friends`` is a list of reference (it could be a list of dicts, nested
+dict, ect.). We *do not* support multiple layers embeddings. This feature is
+about serialization on GET requests. There's no support for POST, PUT or PATCH
+of embedded documents.
 
 Document embedding is enabled by default.
 

--- a/eve/tests/methods/get.py
+++ b/eve/tests/methods/get.py
@@ -473,6 +473,76 @@ class TestGet(TestBase):
         content = json.loads(r.get_data())
         self.assertTrue('location' in content['person'])
 
+    def test_get_reference_embedded_in_subdocuments(self):
+        _db = self.connection[MONGO_DBNAME]
+
+        contacts = self.random_contacts(2)
+        contact_ids = _db.contacts.insert(contacts)
+        company = {'departments': [{'title': 'development',
+                                   'members': contact_ids}]}
+        company_id = _db.companies.insert(company)
+
+        companies = self.domain['companies']
+        contact_ids = list(map(str, contact_ids))
+
+        # Test that doesn't come embedded if asking for a field that
+        # isn't embedded ('embeddable' is False by default)
+        embedded = '{"departments.members": 1}'
+        r = self.test_client.get('%s/%s' % (companies['url'],
+                                            '?embedded=%s' % embedded))
+        self.assert200(r.status_code)
+        content = json.loads(r.get_data())
+        self.assertEqual(content['_items'][0]['departments'][0]['members'],
+                         contact_ids)
+
+        # Set field to be embedded
+        department_def = companies['schema']['departments']['schema']
+        member_def = department_def['schema']['members']['schema']
+        member_def['data_relation']['embeddable'] = True
+
+        # Test that global setting applies even if field is set to embedded
+        companies['embedding'] = False
+        r = self.test_client.get('%s/%s' % (companies['url'],
+                                            '?embedded=%s' % embedded))
+        self.assert200(r.status_code)
+        content = json.loads(r.get_data())
+        self.assertEqual(content['_items'][0]['departments'][0]['members'],
+                         contact_ids)
+
+        # Test that it works
+        companies['embedding'] = True
+        r = self.test_client.get('%s/%s' % (companies['url'],
+                                            '?embedded=%s' % embedded))
+        self.assert200(r.status_code)
+        content = json.loads(r.get_data())
+        self.assertTrue('location' in
+                        content['_items'][0]['departments'][0]['members'][0])
+
+        # Test that it ignores a bogus field
+        embedded = '{"departments.members": 1, "not-a-real-field": 1}'
+        r = self.test_client.get('%s/%s' % (companies['url'],
+                                            '?embedded=%s' % embedded))
+        self.assert200(r.status_code)
+        content = json.loads(r.get_data())
+        self.assertTrue('location' in
+                        content['_items'][0]['departments'][0]['members'][0])
+
+        # Test that it works with item endpoint too
+        embedded = '{"departments.members": 1}'
+        r = self.test_client.get('%s/%s/%s' % (companies['url'], company_id,
+                                               '?embedded=%s' % embedded))
+        self.assert200(r.status_code)
+        content = json.loads(r.get_data())
+        self.assertTrue('location' in content['departments'][0]['members'][0])
+
+        # Test default fields to be embedded
+        companies['embedded_fields'] = {"departments.members": 1}
+        r = self.test_client.get('%s/' % companies['url'])
+        self.assert200(r.status_code)
+        content = json.loads(r.get_data())
+        self.assertTrue('location' in
+                        content['_items'][0]['departments'][0]['members'][0])
+
     def test_get_nested_resource(self):
         response, status = self.get('users/overseas')
         self.assertGet(response, status, 'users_overseas')

--- a/eve/tests/test_settings.py
+++ b/eve/tests/test_settings.py
@@ -124,6 +124,28 @@ invoices = {
     }
 }
 
+companies = {
+    'item_title': 'company',
+    'schema': {
+        'departments': {
+            'type': 'list',
+            'schema': {
+                'type': 'dict',
+                'schema': {
+                    'title': {'type': 'string'},
+                    'members': {
+                        'type': 'list',
+                        'schema': {
+                            'type': 'objectid',
+                            'data_relation': {'resource': 'contacts'}
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
 users_overseas = copy.deepcopy(users)
 users_overseas['url'] = 'users/overseas'
 users_overseas['datasource'] = {'source': 'contacts'}
@@ -152,4 +174,5 @@ DOMAIN = {
     'empty': empty,
     'restricted': user_restricted_access,
     'peopleinvoices': users_invoices,
+    'companies': companies,
 }


### PR DESCRIPTION
Feature allowing to embed documents located in nested dicts and lists. It solves the problem described here: https://github.com/nicolaiarocci/eve/issues/222
Please review the code, let me know if I should amend something and sorry for my English in the docs.

It’s possible now to embed documents by references located in
subdocuments using dot notation.
For example, it’s possible to make the query:
?embedded={“user.friends”:1} for a document which have “user”
subdocument with list of references “friends”.
