### PR TITLE
Fix invalid projection crash

### DIFF
--- a/eve/io/mongo/mongo.py
+++ b/eve/io/mongo/mongo.py
@@ -633,6 +633,8 @@ class Mongo(DataLayer):
         if req and req.projection:
             try:
                 client_projection = json.loads(req.projection)
+                if not isinstance(client_projection, dict):
+                    raise Exception('The projection parameter has to be a dict')
             except:
                 abort(400, description=debug_error_message(
                     'Unable to parse `projection` clause'


### PR DESCRIPTION
To reproduce:

```
GET /endpoint?projection=test
GET /endpoint?projection=["test"]
```
