### PR TITLE
Fix broken media tests for PUT, PATCH and DELETE.

### DIFF
--- a/eve/methods/common.py
+++ b/eve/methods/common.py
@@ -578,7 +578,7 @@ def store_media_files(document, resource, original=None):
     # document update fails we should probably attempt a cleanup on the storage
     # sytem. Easier said than done though.
     for field in resource_media_fields(document, resource):
-        if original and hasattr(original, field):
+        if original and field in original:
             # since file replacement is not supported by the media storage
             # system, we first need to delete the file being replaced.
             app.media.delete(original[field])

--- a/eve/tests/io/media.py
+++ b/eve/tests/io/media.py
@@ -157,8 +157,11 @@ class TestGridFSMediaStorage(TestBase):
         _id = r[ID_FIELD]
         etag = r[ETAG]
 
-        # retrieve media_id and compare original and returned data
-        media_id = self.assertMediaField(_id, self.encoded, self.clean)
+        # compare original and returned data
+        self.assertMediaField(_id, self.encoded, self.clean)
+
+        # retrieve media_id
+        media_id = self.assertMediaStored(_id)
 
         # PUT replaces the file with new one
         clean = b'my new file contents'
@@ -189,8 +192,11 @@ class TestGridFSMediaStorage(TestBase):
         _id = r[ID_FIELD]
         etag = r[ETAG]
 
-        # retrieve media_id and compare original and returned data
-        media_id = self.assertMediaField(_id, self.encoded, self.clean)
+        # compare original and returned data
+        self.assertMediaField(_id, self.encoded, self.clean)
+
+        # retrieve media_id
+        media_id = self.assertMediaStored(_id)
 
         # PATCH replaces the file with new one
         clean = b'my new file contents'
@@ -219,7 +225,9 @@ class TestGridFSMediaStorage(TestBase):
         etag = r[ETAG]
 
         # retrieve media_id and compare original and returned data
-        media_id = self.assertMediaField(_id, self.encoded, self.clean)
+        self.assertMediaField(_id, self.encoded, self.clean)
+
+        media_id = self.assertMediaStored(_id)
 
         # DELETE deletes both the document and the media file
         headers = [('If-Match', etag)]


### PR DESCRIPTION
This PR fixes bug and broken tests: the bug lets previous versions of documents untouched when PUTting or PATCHing some media - they are still stored in the gridfs. This bug was (IMHO) introduced in ad4afe90924241e907e94824b13294bef2c0b217 - calling `hasattr` on variable `original` (which is type `dict`) does not work this way. Tests were poorly coded, so they did not discover the failure: checking return value of `assertMediaField` (which is tuple, not real `media_id`) in `app.media.exists()` returns always `False` (so the tests were useless). Rewritten to `assertMediaStored`, now working as expected.

Please, let me know, if I'm wrong or if I misunderstood these tests.
Cheers.
