### PR TITLE
Fix 500 when POSTing an empty list + prevent crash in case of invalid mongo operation

### DIFF
--- a/eve/io/mongo/mongo.py
+++ b/eve/io/mongo/mongo.py
@@ -312,6 +312,10 @@ class Mongo(DataLayer):
         try:
             return self.driver.db[datasource].insert(doc_or_docs,
                                                      **self._wc(resource))
+        except pymongo.errors.InvalidOperation as e:
+            abort(500, description=debug_error_message(
+                'pymongo.errors.InvalidOperation: %s' % e
+            ))
         except pymongo.errors.OperationFailure as e:
             # most likely a 'w' (write_concern) setting which needs an
             # existing ReplicaSet which doesn't exist. Please note that the

--- a/eve/methods/post.py
+++ b/eve/methods/post.py
@@ -12,8 +12,8 @@
 """
 
 from datetime import datetime
-from flask import current_app as app
-from eve.utils import config, parse_request
+from flask import current_app as app, abort
+from eve.utils import config, parse_request, debug_error_message
 from eve.auth import requires_auth
 from eve.defaults import resolve_default_values
 from eve.validation import ValidationError
@@ -135,6 +135,12 @@ def post(resource, payl=None):
 
     if isinstance(payl, dict):
         payl = [payl]
+
+    if not payl:
+        # empty bulkd insert
+        abort(400, description=debug_error_message(
+            'Empty bulk insert'
+        ))
 
     for value in payl:
         document = []

--- a/eve/tests/methods/post.py
+++ b/eve/tests/methods/post.py
@@ -31,6 +31,10 @@ class TestPost(TestBase):
         self.assertValidationErrorStatus(status)
         self.assertValidationError(r, {'ref': 'required'})
 
+    def test_post_empty_bulk_insert(self):
+        r, status = self.post(self.empty_resource_url, data=[])
+        self.assert400(status)
+
     def test_post_empty_resource(self):
         data = []
         for _ in range(10):


### PR DESCRIPTION
A POST with an empty array leads to a server crash. This fix returns a 400 error instead and ensure server won't crash in case of other mongo invalid operations.
