### PR TITLE
Fix serialization when `type` is missing in schema

### DIFF
--- a/eve/methods/common.py
+++ b/eve/methods/common.py
@@ -301,10 +301,10 @@ def serialize(document, resource=None, schema=None, fields=None):
         for field in fields:
             if field in schema:
                 field_schema = schema[field]
-                field_type = field_schema['type']
+                field_type = field_schema.get('type')
                 if 'schema' in field_schema:
                     field_schema = field_schema['schema']
-                    if 'dict' in (field_type, field_schema.get('type', '')):
+                    if 'dict' in (field_type, field_schema.get('type')):
                         # either a dict or a list of dicts
                         embedded = [document[field]] if field_type == 'dict' \
                             else document[field]
@@ -315,8 +315,8 @@ def serialize(document, resource=None, schema=None, fields=None):
                             else:
                                 serialize(subdocument, schema=field_schema)
                     else:
-                        # a list of one type, arbirtrary length
-                        field_type = field_schema['type']
+                        # a list of one type, arbitrary length
+                        field_type = field_schema.get('type')
                         if field_type in app.data.serializers:
                             for i, v in enumerate(document[field]):
                                 document[field][i] = \
@@ -325,7 +325,7 @@ def serialize(document, resource=None, schema=None, fields=None):
                     # a list of multiple types, fixed length
                     for i, (s, v) in enumerate(zip(field_schema['items'],
                                                    document[field])):
-                        field_type = s['type'] if 'type' in s else None
+                        field_type = s.get('type')
                         if field_type in app.data.serializers:
                             document[field][i] = \
                                 app.data.serializers[field_type](

--- a/eve/tests/methods/common.py
+++ b/eve/tests/methods/common.py
@@ -11,9 +11,11 @@ class TestSerializer(TestBase):
         # tests fix for #244, serialization of sub-documents.
         schema = {'personal': {'type': 'dict',
                                'schema': {'best_friend': {'type': 'objectid'},
-                                          'born': {'type': 'datetime'}}}}
+                                          'born': {'type': 'datetime'}}},
+                  'without_type': {}}
         doc = {'personal': {'best_friend': '50656e4538345b39dd0414f0',
-                            'born': 'Tue, 06 Nov 2012 10:33:31 GMT'}}
+                            'born': 'Tue, 06 Nov 2012 10:33:31 GMT'},
+               'without_type': 'foo'}
         with self.app.app_context():
             serialized = serialize(doc, schema=schema)
         self.assertTrue(


### PR DESCRIPTION
Serialization fails with KeyError exception in the case when type definition of a field if missing in the schema. However, the exception is silently caught by `parse` function that calls the serialization and the result is that remaining fields are not serialized. As the order of dictionary keys in document is random, the consequence are unexplainable errors `value '52f89dea4e03c0f71f64d334' cannot be converted to a ObjectId` and `must be of datetime type` for correct _objectid_ and _datetime_ values and those errors appear and disappear unpredictably. The PR fixes this behavior.

Fields without type definition in schema are useful for polymorphic fields that may contain any object, but the field name is given and unknown fields are not allowed to insert.
