### PR TITLE
Allow the auth. in domain config to be a Class

### DIFF
--- a/eve/auth.py
+++ b/eve/auth.py
@@ -40,7 +40,10 @@ def requires_auth(endpoint_class):
                         roles += resource['allowed_item_read_roles']
                     else:
                         roles += resource['allowed_item_write_roles']
-                auth = resource['authentication']
+                if callable(resource['authentication']):
+                    auth = resource['authentication']()
+                else:
+                    auth = resource['authentication']
             else:
                 # home
                 resource_name = resource = None


### PR DESCRIPTION
My env: Python 3.4.1 @ Windows 7 x64

Hi,

When I tried to follow http://python-eve.org/config.html#domain-configuration to set a Class as the auth of a domain, it failed.

So I referred to [flaskapp.py:144](/nicolaiarocci/eve/blob/develop/eve/flaskapp.py#L144) and tried this fix.  It seems to work for me.

I'm very new to Python so I don't know if this is proper or not.  And I don't know how to write test or doc either.  So I just want to contribute my idea in case you will like it.
