### PR TITLE
Fix app initialization with resource level versioning

### DIFF
--- a/eve/tests/test_settings.py
+++ b/eve/tests/test_settings.py
@@ -131,6 +131,11 @@ invoices = {
     }
 }
 
+# This resource is used to test app initialization when using resource
+# level versioning
+versioned_invoices = copy.deepcopy(invoices)
+versioned_invoices['versioning'] = True
+
 companies = {
     'item_title': 'company',
     'schema': {
@@ -177,6 +182,7 @@ DOMAIN = {
     'users': users,
     'users_overseas': users_overseas,
     'invoices': invoices,
+    'versioned_invoices': versioned_invoices,
     'payments': payments,
     'empty': empty,
     'restricted': user_restricted_access,


### PR DESCRIPTION
When using resource level versioning, the initial iteration to register
each resource would raise a RuntimeError because of versioned resources
being inserted into DOMAIN at the same time it's being iterated. A
snapshot of DOMAIN is used for iteration to fix this.

Also, new versioned resources are passed through _add_resource_url_rules
to fix some tests needing them to be in config['URLS'].

This doesn't add tests for this specific case but adds a new
`versioned_invoices` resource to eve.tests.test_settings with
versioning enabled in the resource level.
