### PR TITLE
Support configuration from dotted module path

### DIFF
--- a/eve/flaskapp.py
+++ b/eve/flaskapp.py
@@ -198,7 +198,10 @@ class Eve(Flask, Events):
             else:
                 abspath = os.path.abspath(os.path.dirname(sys.argv[0]))
                 pyfile = os.path.join(abspath, self.settings)
-            self.config.from_pyfile(pyfile)
+            if os.path.exists(pyfile):
+                self.config.from_pyfile(pyfile)
+            else:
+                self.config.from_object(self.settings)
 
         # overwrite settings with custom environment variable
         envvar = 'EVE_SETTINGS'


### PR DESCRIPTION
If the passed settings string does not exist, try to load it as per
Flask's config.from_object method.

Ideally, just supporting the Flask way of loading configuration
would give us broader options. So, it'd be great to use this to
start discussing improvements over the configuration loading.
