### PR TITLE
add support for list of strings as default value for fields

### DIFF
--- a/eve/defaults.py
+++ b/eve/defaults.py
@@ -109,7 +109,11 @@ def resolve_default_values(document, defaults):
             if isinstance(value, list) and len(value):
                 existing = document.get(name)
                 if not existing:
+                    document.setdefault(name, value)
                     continue
-                todo.extend((value[0], item) for item in existing)
+                if all(isinstance(item, (dict, list)) for item in existing):
+                    todo.extend((value[0], item) for item in existing)
+                else:
+                    document.setdefault(name, existing)
             else:
                 document.setdefault(name, value)

--- a/eve/tests/default_values.py
+++ b/eve/tests/default_values.py
@@ -222,6 +222,19 @@ class TestResolveDefaultValues(unittest.TestCase):
         expected = {'a': ['b']}
         assert expected == document
 
+    def test_list_of_strings_as_default(self):
+        document = {}
+        defaults = {'a': ['b']}
+        resolve_default_values(document, defaults)
+        expected = {'a': ['b']}
+        assert expected == document
+        # overwrite defaults
+        document = {'a': ['c', 'd']}
+        defaults = {'a': ['b']}
+        resolve_default_values(document, defaults)
+        expected = {'a': ['c', 'd']}
+        assert expected == document
+
     def test_list_of_list_dict_value(self):
         document = {'one': [[{}], [{}]]}
         defaults = {'one': [[{'name': 'banana'}]]}


### PR DESCRIPTION
For my accounts schema I want to have a default value for the roles field. This is the schema should look like this:

```
'roles': {
    'type': 'list',
    'allowed': ['user', 'superuser', 'admin'],
    'default': ['user']
}
```

This worked in the past, but behavior seems to have changed in version 0.4. Now the default value is simply ignored. I can restore the old behavior with these changes and I think there are no site effects.

@nicolaiarocci would be nice if you could have a look at this.

Regards
