### PR TITLE
Add extra 4xx response codes for proper handling

### DIFF
--- a/eve/flaskapp.py
+++ b/eve/flaskapp.py
@@ -748,5 +748,5 @@ class Eve(Flask, Events):
 
         .. versionadded:: 0.4
         """
-        for code in [400, 401, 403, 404, 422]:
+        for code in [400, 401, 403, 404, 405, 406, 409, 410, 422]:
             self.error_handler_spec[None][code] = error_endpoint


### PR DESCRIPTION
Only 405 Method not allowed, 406 Not acceptable, 409 Conflict, and 410 Gone have been added to the list. Hard-coding every possible 4xx error felt too unruly...perhaps there could be a global setting where extra 4xx errors can be supplied if desired?
