### PR TITLE
Do not follow DATE_FORMAT for HTTP headers (fix #429)

### DIFF
--- a/eve/render.py
+++ b/eve/render.py
@@ -16,7 +16,8 @@ import simplejson as json
 from werkzeug import utils
 from functools import wraps
 from eve.methods.common import get_rate_limit
-from eve.utils import date_to_str, config, request_method, debug_error_message
+from eve.utils import date_to_str, date_to_rfc1123, config, request_method, \
+    debug_error_message
 from flask import make_response, request, Response, current_app as app, abort
 
 # mapping between supported mime types and render functions.
@@ -161,7 +162,7 @@ def _prepare_response(resource, dct, last_modified=None, etag=None,
     if etag:
         resp.headers.add('ETag', etag)
     if last_modified:
-        resp.headers.add('Last-Modified', date_to_str(last_modified))
+        resp.headers.add('Last-Modified', date_to_rfc1123(last_modified))
 
     # CORS
     origin = request.headers.get('Origin')

--- a/eve/tests/methods/get.py
+++ b/eve/tests/methods/get.py
@@ -6,7 +6,7 @@ from bson import ObjectId
 from eve.tests import TestBase
 from eve.tests.utils import DummyEvent
 from eve.tests.test_settings import MONGO_DBNAME
-from eve.utils import date_to_str, str_to_date
+from eve.utils import str_to_date, date_to_rfc1123
 
 
 class TestGet(TestBase):
@@ -1006,7 +1006,7 @@ class TestGetItem(TestBase):
 
         # IMS needs to see as recent as possible since the test db has just
         # been built
-        header = [("If-Modified-Since", date_to_str(datetime.now()))]
+        header = [("If-Modified-Since", date_to_rfc1123(datetime.now()))]
 
         r = self.test_client.get(self.item_id_url, headers=header)
         self.assert304(r.status_code)

--- a/eve/utils.py
+++ b/eve/utils.py
@@ -163,7 +163,8 @@ def weak_date(date):
 
 
 def str_to_date(string):
-    """ Converts a RFC-1123 string to the corresponding datetime value.
+    """ Converts a date string formatted as defined in the configuration
+        to the corresponding datetime value.
 
     :param string: the RFC-1123 string to convert to datetime value.
     """
@@ -171,12 +172,18 @@ def str_to_date(string):
 
 
 def date_to_str(date):
-    """ Converts a datetime value to the corresponding RFC-1123 string.
+    """ Converts a datetime value to the format defined in the configuration file.
 
     :param date: the datetime value to convert.
     """
     return datetime.strftime(date, config.DATE_FORMAT) if date else None
 
+def date_to_rfc1123(date):
+    """ Converts a datetime value to the corresponding RFC-1123 string.
+
+    :param date: the datetime value to convert.
+    """
+    return datetime.strftime(date, '%a, %d %b %Y %H:%M:%S GMT') if date else None
 
 def home_link():
     """ Returns a link to the API entry point/home page.


### PR DESCRIPTION
When DATE_FORMAT format is customized, the Last-Modified HTTP header is changed to match the customized format. That make Eve's HTTP responses no longer RFC compliant.

The DATE_FORMAT configuration parameter should only affect the way dates are returned by the API, not how HTTP headers are formated.
