### PR TITLE
use rfc1123 date format for weak_date

### DIFF
--- a/eve/tests/utils.py
+++ b/eve/tests/utils.py
@@ -140,8 +140,10 @@ class TestUtils(TestBase):
                              self.etag)
 
     def test_weak_date(self):
-        self.assertEqual(weak_date(self.datestr), self.valid +
-                         timedelta(seconds=1))
+        with self.app.test_request_context():
+            self.app.config['DATE_FORMAT'] = '%Y-%m-%d'
+            self.assertEqual(weak_date(self.datestr), self.valid +
+                             timedelta(seconds=1))
 
     def test_str_to_date(self):
         self.assertEqual(str_to_date(self.datestr), self.valid)

--- a/eve/utils.py
+++ b/eve/utils.py
@@ -19,6 +19,9 @@ from bson.json_util import dumps
 import werkzeug.exceptions
 
 
+RFC1123_DATE_FORMAT = '%a, %d %b %Y %H:%M:%S GMT'
+
+
 class Config(object):
     """ Helper class used trorough the code to access configuration settings.
     If the main flaskapp object is not instantiated yet, returns the default
@@ -159,7 +162,7 @@ def weak_date(date):
 
     :param date: the date to be adjusted.
     """
-    return str_to_date(date) + timedelta(seconds=1) if date else None
+    return datetime.strptime(date, RFC1123_DATE_FORMAT) + timedelta(seconds=1) if date else None
 
 
 def str_to_date(string):
@@ -183,7 +186,7 @@ def date_to_rfc1123(date):
 
     :param date: the datetime value to convert.
     """
-    return datetime.strftime(date, '%a, %d %b %Y %H:%M:%S GMT') if date else None
+    return datetime.strftime(date, RFC1123_DATE_FORMAT) if date else None
 
 def home_link():
     """ Returns a link to the API entry point/home page.


### PR DESCRIPTION
while headers are always sent using this format, it should be also used
when parsing the date
