### PR TITLE
fix get document when missing embedded with media

### DIFF
--- a/eve/methods/common.py
+++ b/eve/methods/common.py
@@ -515,7 +515,8 @@ def embedded_document(reference, data_relation, field_name):
         subresource = data_relation['resource']
         embedded_doc = app.data.find_one(subresource, None,
                                          **{config.ID_FIELD: reference})
-        resolve_media_files(embedded_doc, subresource)
+        if embedded_doc:
+            resolve_media_files(embedded_doc, subresource)
 
     return embedded_doc
 


### PR DESCRIPTION
in case you try to embedd a document which has media fields and that
document was deleted meanwhile there is an exception from:

`[field for field in media_fields if field in document]`

because document is `None`
