### PR TITLE
add missing MongoDB operators to the list

### DIFF
--- a/eve/io/mongo/mongo.py
+++ b/eve/io/mongo/mongo.py
@@ -70,7 +70,8 @@ class Mongo(DataLayer):
     operators = set(
         ['$gt', '$gte', '$in', '$lt', '$lt', '$lte', '$ne', '$nin'] +
         ['$or', '$and', '$not', '$nor'] +
-        ['$mod', '$regex', '$options', '$text', '$search', '$language', '$where'] +
+        ['$mod', '$regex', '$text', '$where'] +
+        ['$options', '$search', '$language'] +
         ['$exists', '$type'] +
         ['$geoWithin', '$geoIntersects', '$near', '$nearSphere'] +
         ['$all', '$elemMatch', '$size']


### PR DESCRIPTION
Sub-operators of $regex and $text are missing in the list of all MongoDB operators. Without this fix when allowing $regex (removing from blacklist) in API instance, a request with $regex and $options fails with `unknown operator: $options` error.
