### PR TITLE
Add <method>_internal methods for all Eve methods

### DIFF
--- a/eve/methods/delete.py
+++ b/eve/methods/delete.py
@@ -21,7 +21,19 @@ from eve.versioning import versioned_id_field
 @requires_auth('item')
 @pre_event
 def deleteitem(resource, **lookup):
-    """ Deletes a resource item. Deletion will occur only if request ETag
+  """
+  Default function for handling DELETE requests on items. It has decorators
+  for rate limiting, authentication and for raising pre-request events. After
+  the decorators are applied forwards to call to :func:`post_internal`
+  """
+  return deleteitem_internal(resource, **lookup)
+
+def deleteitem_internal(resource, **lookup):
+    """
+    Intended for internal delete calls, this method is not rate limited,
+    authentication is not checked and pre-request events are not raised.
+
+    Deletes a resource item. Deletion will occur only if request ETag
     matches the current representation of the item.
 
     :param resource: name of the resource to which the item(s) belong.
@@ -94,7 +106,19 @@ def deleteitem(resource, **lookup):
 @requires_auth('resource')
 @pre_event
 def delete(resource, **lookup):
-    """ Deletes all item of a resource (collection in MongoDB terms). Won't
+    """
+    Default function for handling DELETE requests on resource. It has decorators
+    for rate limiting, authentication and for raising pre-request events. After
+    the decorators are applied forwards to call to :func:`post_internal`
+    """
+    return delete_internal(resource, **lookup)
+
+def delete_internal(resource, **lookup):
+    """
+    Intended for internal delete calls, this method is not rate limited,
+    authentication is not checked and pre-request events are not raised.
+
+    Deletes all item of a resource (collection in MongoDB terms). Won't
     drop indexes. Use with caution!
 
     .. versionchanged:: 0.4

--- a/eve/methods/get.py
+++ b/eve/methods/get.py
@@ -25,7 +25,19 @@ from eve.versioning import synthesize_versioned_document, versioned_id_field, \
 @requires_auth('resource')
 @pre_event
 def get(resource, **lookup):
-    """ Retrieves the resource documents that match the current request.
+    """
+    Default function for handling GET requests on resources. It has decorators
+    for rate limiting, authentication and for raising pre-request events. After
+    the decorators are applied forwards to call to :func:`post_internal`
+    """
+    return get_internal(resource, **lookup)
+
+def get_internal(resource, **lookup):
+    """
+    Intended for internal get calls, this method is not rate limited,
+    authentication is not checked and pre-request events are not raised.
+
+    Retrieves the resource documents that match the current request.
 
     :param resource: the name of the resource.
 
@@ -139,6 +151,17 @@ def get(resource, **lookup):
 @pre_event
 def getitem(resource, **lookup):
     """
+    Default function for handling GET requests on resources. It has decorators
+    for rate limiting, authentication and for raising pre-request events. After
+    the decorators are applied forwards to call to :func:`post_internal`
+    """
+    return getitem_internal(resource, **lookup)
+
+def getitem_internal(resource, **lookup):
+    """
+    Intended for internal get calls, this method is not rate limited,
+    authentication is not checked and pre-request events are not raised.
+
     :param resource: the name of the resource to which the document belongs.
     :param **lookup: the lookup query.
 

--- a/eve/methods/patch.py
+++ b/eve/methods/patch.py
@@ -27,7 +27,19 @@ from eve.versioning import resolve_document_version, \
 @requires_auth('item')
 @pre_event
 def patch(resource, **lookup):
-    """ Perform a document patch/update. Updates are first validated against
+    """
+    Default function for handling PATCH requests, it has decorators for
+    rate limiting, authentication and for raising pre-request events. After the
+    decorators are applied forwards to call to :func:`post_internal`
+    """
+    return patch_internal(resource, **lookup)
+
+def patch_internal(resource, **lookup):
+    """
+    Intended for internal post calls, this method is not rate limited,
+    authentication is not checked and pre-request events are not raised.
+
+    Perform a document patch/update. Updates are first validated against
     the resource schema. If validation passes, the document is updated and
     an OK status update is returned. If validation fails, a set of validation
     issues is returned.


### PR DESCRIPTION
There is a `post_internal` method to perform internal POSTs. This PR adds same kind of methods for all other methods.
