### PR TITLE
New config setting for CORS Access-Control-Expose-Headers #467

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -16,6 +16,7 @@ Patches and Contributions
 - Brian Mego
 - Bryan Cattle
 - boosh
+- Christian Henke
 - Christoph Witzany
 - Christopher Larsen
 - Daniele Pizzolli

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -256,6 +256,13 @@ uppercase.
                                     a list of headers names. Defaults to
                                     ``None``.
                                 
+``X_EXPOSE_HEADERS``                CORS (Cross-Origin Resource Sharing) support.
+                                    Allows API maintainers to specify which
+                                    headers are exposed within a CORS response.
+                                    Allowed values are: ``None`` or
+                                    a list of headers names. Defaults to
+                                    ``None``.
+
 ``X_MAX_AGE``                       CORS (Cross-Origin Resource Sharing) 
                                     support. Allows to set max age for the
                                     access control allow header. Defaults to

--- a/eve/default_settings.py
+++ b/eve/default_settings.py
@@ -102,6 +102,7 @@ CACHE_EXPIRES = 0
 ITEM_CACHE_CONTROL = ''
 X_DOMAINS = None                # CORS disabled by default.
 X_HEADERS = None                # CORS disabled by default.
+X_EXPOSE_HEADERS = None         # CORS disabled by default.
 X_MAX_AGE = 21600               # Access-Control-Max-Age when CORS is enabled
 HATEOAS = True                  # HATEOAS enabled by default.
 IF_MATCH = True                 # IF_MATCH (ETag match) enabled by default.

--- a/eve/render.py
+++ b/eve/render.py
@@ -185,6 +185,13 @@ def _prepare_response(resource, dct, last_modified=None, etag=None,
         else:
             headers = config.X_HEADERS
 
+        if config.X_EXPOSE_HEADERS is None:
+            expose_headers = []
+        elif isinstance(config.X_EXPOSE_HEADERS, str):
+            expose_headers = [config.X_EXPOSE_HEADERS]
+        else:
+            expose_headers = config.X_EXPOSE_HEADERS
+
         methods = app.make_default_options_response().headers.get('allow', '')
 
         if '*' in domains or origin in domains:
@@ -192,6 +199,7 @@ def _prepare_response(resource, dct, last_modified=None, etag=None,
         else:
             resp.headers.add('Access-Control-Allow-Origin', '')
         resp.headers.add('Access-Control-Allow-Headers', ', '.join(headers))
+        resp.headers.add('Access-Control-Expose-Headers', ', '.join(expose_headers))
         resp.headers.add('Access-Control-Allow-Methods', methods)
         resp.headers.add('Access-Control-Allow-Max-Age', config.X_MAX_AGE)
 

--- a/eve/tests/renders.py
+++ b/eve/tests/renders.py
@@ -102,6 +102,7 @@ class TestRenders(TestBase):
         self.assertFalse('Access-Control-Allow-Origin' in r.headers)
         self.assertFalse('Access-Control-Allow-Methods' in r.headers)
         self.assertFalse('Access-Control-Allow-Max-Age' in r.headers)
+        self.assertFalse('Access-Control-Expose-Headers' in r.headers)
         self.assert200(r.status_code)
 
         # test that if X_DOMAINS is set to '*', then any Origin value is
@@ -137,6 +138,7 @@ class TestRenders(TestBase):
         self.assertTrue('Access-Control-Allow-Headers' in r.headers)
         self.assertTrue('Access-Control-Allow-Methods' in r.headers)
         self.assertTrue('Access-Control-Allow-Max-Age' in r.headers)
+        self.assertTrue('Access-Control-Expose-Headers' in r.headers)
 
     def test_CORS_MAX_AGE(self):
         self.app.config['X_DOMAINS'] = '*'
@@ -159,6 +161,7 @@ class TestRenders(TestBase):
         self.assertFalse('Access-Control-Allow-Origin' in r.headers)
         self.assertFalse('Access-Control-Allow-Methods' in r.headers)
         self.assertFalse('Access-Control-Allow-Max-Age' in r.headers)
+        self.assertFalse('Access-Control-Expose-Headers' in r.headers)
         self.assert200(r.status_code)
 
         # test that if X_DOMAINS is set to '*', then any Origin value is
@@ -190,6 +193,7 @@ class TestRenders(TestBase):
 
         self.assertTrue('Access-Control-Allow-Origin' in r.headers)
         self.assertTrue('Access-Control-Allow-Max-Age' in r.headers)
+        self.assertTrue('Access-Control-Expose-Headers' in r.headers)
 
         r = self.test_client.get(url, headers=[('Origin',
                                                 'http://not_an_example.com')])


### PR DESCRIPTION
Like the Access-Control-Allow-Headers directive allows the
the use of specific headers inside CORS requests, the
Access-Control-Expose-Headers directive allows access to
specific headers of the CORS response which are otherwise
inaccessible. A good example for this is the 'ETag' header
(that the client is interested in for sending it later inside
an 'If-Match' header).
This change makes the exposed headers configurable.
