### PR TITLE
update tests for py26 compatibility

### DIFF
--- a/eve/tests/io/sql.py
+++ b/eve/tests/io/sql.py
@@ -144,7 +144,7 @@ class TestSQLStructures(TestCase):
         r = SQLAResult(self.person, self.fields)
         self.assertEqual(r.keys(), self.fields)
         self.assertEqual(len(r), len(self.fields))
-        self.assertIn('prog', r.keys())
+        self.assertTrue('prog' in r.keys())
 
     def test_sql_result_get(self):
         r = SQLAResult(self.person, self.fields)
@@ -154,7 +154,7 @@ class TestSQLStructures(TestCase):
     def test_sql_result_set(self):
         r = SQLAResult(self.person, self.fields)
         r['dummy'] = 5
-        self.assertIn('dummy', r.keys())
+        self.assertTrue('dummy' in r.keys())
         self.assertEqual(len(r), len(self.fields) + 1)
         self.assertEqual(r['dummy'], 5)
 

--- a/eve/tests/methods/post_sql.py
+++ b/eve/tests/methods/post_sql.py
@@ -137,8 +137,8 @@ class TestPostSQL(TestBaseSQL):
         data = {test_field: test_value}
         r, status = self.post(self.known_resource_url, data=data)
         self.assert201(status)
-        self.assertIn('firstname', r)
-        self.assertNotIn('nah', r)
+        self.assertTrue('firstname' in r)
+        self.assertFalse('nah' in r)
 
     def test_post_with_get_override(self):
         # a GET request with POST override turns into a POST request.


### PR DESCRIPTION
I haven't noticed last problem on `py26` the `assertIn` is also missing in `<py27`. Changed.
