### PR TITLE
Fix validation of read-only fields inside dicts #474

### DIFF
--- a/eve/io/mongo/validation.py
+++ b/eve/io/mongo/validation.py
@@ -198,7 +198,7 @@ class Validator(Validator):
 
         .. versionadded:: 0.4
         """
-        default = config.DOMAIN[self.resource]['schema'][field].get('default')
+        default = self.schema[field].get('default')
         original_value = self._original_document.get(field) \
             if self._original_document else None
         if value not in (default, original_value):

--- a/eve/tests/methods/post.py
+++ b/eve/tests/methods/post.py
@@ -418,6 +418,15 @@ class TestPost(TestBase):
         data = {test_field: test_value}
         self.assertPostItem(data, test_field, test_value)
 
+    def test_post_readonly_in_dict(self):
+        # Test that a post with a readonly field inside a dict is correctly
+        # validated and doesn't return an exception error
+        del(self.domain['contacts']['schema']['ref']['required'])
+        test_field = 'dict_with_read_only'
+        test_value = {'read_only_in_dict': 'default'}
+        data = {test_field: test_value}
+        self.assertPostItem(data, test_field, test_value)
+
     def test_post_keyschema_dict(self):
         """ make sure Cerberus#48 is fixed """
         del(self.domain['contacts']['schema']['ref']['required'])

--- a/eve/tests/test_settings.py
+++ b/eve/tests/test_settings.py
@@ -100,6 +100,16 @@ contacts = {
             'default': 'default',
             'readonly': True
         },
+        'dict_with_read_only': {
+            'type': 'dict',
+            'schema': {
+                'read_only_in_dict': {
+                    'type': 'string',
+                    'default': 'default',
+                    'readonly': True
+                }
+            }
+        },
         'key1': {
             'type': 'string',
         },

--- a/eve/tests/versioning.py
+++ b/eve/tests/versioning.py
@@ -33,6 +33,8 @@ class TestVersioningBase(TestBase):
         del(self.domain['contacts']['schema']['title']['default'])
         del(self.domain['contacts']['schema']['dependency_field1']['default'])
         del(self.domain['contacts']['schema']['read_only_field']['default'])
+        del(self.domain['contacts']['schema']['dict_with_read_only']
+                       ['schema']['read_only_in_dict']['default'])
         if partial is True:
             contact_schema = self.domain['contacts']['schema']
             contact_schema[self.unversioned_field]['versioned'] = False


### PR DESCRIPTION
As the default values are resolved before validation,
the validation method of readonly fields needs to know about an
 eventual default value of the field in order to skip validation if
the value being validated matches the default.

The default value was being fetched from the schema definition, which
raised a KeyError when the read-only field was not in the first level of
the document, but inside a dict.

This is fixed by getting the default value from the schema attribute
instead.

closes #474
