### PR TITLE
Fix and add regression test for bug in _mongotize() (#508)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -67,6 +67,7 @@ Patches and Contributions
 - Nicolas Carlier
 - Olivier Poitrey
 - Ondrej Slinták
+- Or Neeman
 - Petr Jašek
 - Paul Doucet
 - Robert Wlodarczyk

--- a/eve/io/mongo/mongo.py
+++ b/eve/io/mongo/mongo.py
@@ -617,7 +617,9 @@ class Mongo(DataLayer):
             except:
                 if not skip_objectid:
                     try:
-                        return ObjectId(v)
+                        # Convert to unicode because ObjectId() interprets 12-character strings (but not unicode) as
+                        # binary representations of ObjectId's.  See https://github.com/nicolaiarocci/eve/issues/508
+                        return ObjectId(unicode(v))
                     except:
                         return v
                 else:

--- a/eve/tests/methods/get.py
+++ b/eve/tests/methods/get.py
@@ -3,6 +3,7 @@ from io import BytesIO
 import simplejson as json
 from datetime import datetime
 from bson import ObjectId
+from werkzeug.datastructures import ImmutableMultiDict
 from eve.tests import TestBase
 from eve.tests.utils import DummyEvent
 from eve.tests.test_settings import MONGO_DBNAME
@@ -1186,6 +1187,20 @@ class TestEvents(TestBase):
         self.app.on_pre_GET += filter_this
         # Would normally return all documents; will only just one.
         r, s = self.parse_response(self.get_resource())
+        self.assertEqual(len(r[self.app.config['ITEMS']]), 1)
+
+    def test_on_pre_GET_resource_dynamic_filter_12_character_nonunicode_string(self):
+        # Test for bug in _mongotize().  See https://github.com/nicolaiarocci/eve/issues/508
+        def filter_this(request, lookup):
+            request.args = ImmutableMultiDict({"where": '{"name":"Alice Brooks"}'})
+        self.app.register_resource(
+            'names',
+            {'schema': {'name': {'type': 'string'}}}
+        )
+        # We want to test with a non-unicode string for 'where', so we need to do it with a pre_GET callback
+        self.app.on_pre_GET_names += filter_this
+        self.post('names', data={"name": "Alice Brooks"})
+        r, s = self.get('names')
         self.assertEqual(len(r[self.app.config['ITEMS']]), 1)
 
     def test_on_pre_GET_resource_for_resource(self):


### PR DESCRIPTION
Fix for https://github.com/nicolaiarocci/eve/issues/508 , including a regression test that fails (in Python 2.x) without the fix.  The build fails on Python 3.x, but that was already the case with the develop branch prior to my commit.
