### PR TITLE
Fix skipping dependencies with default values

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -70,6 +70,7 @@ Patches and Contributions
 - Or Neeman
 - Petr Jašek
 - Paul Doucet
+- Peter Darrow
 - Robert Wlodarczyk
 - Roberto 'Kalamun' Pasini
 - Ronan Delacroix

--- a/eve/io/mongo/mongo.py
+++ b/eve/io/mongo/mongo.py
@@ -8,7 +8,6 @@
     :license: BSD, see LICENSE for more details.
 """
 
-import sys
 import ast
 import itertools
 from bson.errors import InvalidId
@@ -22,7 +21,7 @@ from datetime import datetime
 from eve.io.mongo.parser import parse, ParseError
 from eve.io.base import DataLayer, ConnectionException, BaseJSONEncoder
 from eve.utils import config, debug_error_message, validate_filters, \
-    str_to_date
+    str_to_date, str_type
 
 
 class MongoJSONEncoder(BaseJSONEncoder):
@@ -604,11 +603,6 @@ class Mongo(DataLayer):
 
         .. versionadded:: 0.0.4
         """
-        if sys.version_info[0] == 3:
-            _str_type = str
-        else:
-            _str_type = basestring  # noqa
-
         schema = config.DOMAIN[resource]
         skip_objectid = schema.get('query_objectid_as_string', False)
 
@@ -642,7 +636,7 @@ class Mongo(DataLayer):
                         source[k][i] = self._mongotize(v1, resource)
                     else:
                         source[k][i] = try_cast(v1)
-            elif isinstance(v, _str_type):
+            elif isinstance(v, str_type):
                 source[k] = try_cast(v)
 
         return source

--- a/eve/io/mongo/validation.py
+++ b/eve/io/mongo/validation.py
@@ -13,8 +13,8 @@
 """
 
 import copy
-from collections import Sequence
-from eve.utils import config
+from collections import Mapping
+from eve.utils import config, str_type
 from bson import ObjectId
 from flask import current_app as app
 from cerberus import Validator
@@ -219,11 +219,15 @@ class Validator(Validator):
            dependency (#353).
            Fix for #363 (see docstring).
         """
-        if not isinstance(dependencies, Sequence):
+        # Ensure `dependencies` is a list
+        if isinstance(dependencies, str_type):
             dependencies = [dependencies]
-        for field in dependencies:
-            if self.schema[field].get('default'):
-                dependencies.remove(field)
+        elif isinstance(dependencies, Mapping):
+            dependencies = dependencies.keys()
+
+        # Filter out dependencies with default values
+        dependencies = [d for d in dependencies
+                        if self.schema[d].get('default') is None]
 
         dcopy = None
         if self._original_document:

--- a/eve/tests/io/mongo.py
+++ b/eve/tests/io/mongo.py
@@ -240,6 +240,28 @@ class TestMongoValidator(TestCase):
         v = Validator(schema)
         self.assertTrue(v.validate(doc))
 
+    def test_dependencies_with_defaults(self):
+        schema = {
+            'test_field': {'dependencies': 'foo'},
+            'foo': {'type': 'string', 'default': 'foo'},
+            'bar': {'type': 'string', 'default': 'bar'}
+        }
+        doc = {'test_field': 'foobar'}
+
+        # With `dependencies` as a str
+        v = Validator(schema)
+        self.assertTrue(v.validate(doc))
+
+        # With `dependencies` as a dict
+        schema['test_field'] = {'foo': 'foo', 'bar': 'bar'}
+        v = Validator(schema)
+        self.assertTrue(v.validate(doc))
+
+        # With `dependencies` as a list
+        schema['test_field'] = {'dependencies': ['foo', 'bar']}
+        v = Validator(schema)
+        self.assertTrue(v.validate(doc))
+
 
 class TestMongoDriver(TestCase):
     def test_combine_queries(self):

--- a/eve/utils.py
+++ b/eve/utils.py
@@ -10,6 +10,7 @@
     :license: BSD, see LICENSE for more details.
 """
 
+import sys
 import eve
 import hashlib
 import werkzeug.exceptions
@@ -380,3 +381,6 @@ def auto_fields(resource):
         fields.append(config.ID_FIELD + config.VERSION_ID_SUFFIX)
 
     return fields
+
+# Base string type that is compatible with both Python 2.x and 3.x.
+str_type = str if sys.version_info[0] == 3 else basestring


### PR DESCRIPTION
There are no tests for `_validate_dependencies` so a bug slipped in with the fix for #353 where dependencies with default values were not being skipped properly. This pull request fixes that and adds the missing test coverage.
