### PR TITLE
Added support for validation on field attribute with type list

### DIFF
--- a/eve/io/mongo/validation.py
+++ b/eve/io/mongo/validation.py
@@ -166,12 +166,18 @@ class Validator(Validator):
                     " with fields '%s' and '%s'" %
                     (value_field, version_field))
         else:
-            query = {data_relation['field']: value}
-            if not app.data.find_one(data_relation['resource'], None, **query):
-                self._error(
-                    field,
-                    "value '%s' must exist in resource '%s', field '%s'." %
-                    (value, data_relation['resource'], data_relation['field']))
+            if not isinstance(value, list):
+                value = [value]
+
+            data_resource = data_relation['resource']
+            for item in value:
+                    query = {data_relation['field']: item}
+                    if not app.data.find_one(data_resource, None, **query):
+                        self._error(
+                            field,
+                            "value '%s' must exist in resource"
+                            " '%s', field '%s'." %
+                            (item, data_resource, data_relation['field']))
 
     def _validate_type_objectid(self, field, value):
         """ Enables validation for `objectid` data type.

--- a/eve/tests/methods/post.py
+++ b/eve/tests/methods/post.py
@@ -211,6 +211,20 @@ class TestPost(TestBase):
         self.assert201(status)
         self.assertPostResponse(r)
 
+    def test_post_referential_integrity_list(self):
+        data = {"invoicing_contacts": [self.item_id, self.unknown_item_id]}
+        r, status = self.post('/invoices/', data=data)
+        self.assertValidationErrorStatus(status)
+        expected = ("value '%s' must exist in resource '%s', field '%s'" %
+                    (self.unknown_item_id, 'contacts',
+                     self.app.config['ID_FIELD']))
+        self.assertValidationError(r, {'invoicing_contacts': expected})
+
+        data = {"invoicing_contacts": [self.item_id, self.item_id]}
+        r, status = self.post('/invoices/', data=data)
+        self.assert201(status)
+        self.assertPostResponse(r)
+
     def test_post_allow_unknown(self):
         del(self.domain['contacts']['schema']['ref']['required'])
         data = {"unknown": "unknown"}

--- a/eve/tests/methods/put.py
+++ b/eve/tests/methods/put.py
@@ -107,6 +107,21 @@ class TestPut(TestBase):
         self.assert200(status)
         self.assertPutResponse(r, self.invoice_id)
 
+    def test_put_referential_integrity_list(self):
+        data = {"invoicing_contacts": [self.item_id, self.unknown_item_id]}
+        headers = [('If-Match', self.invoice_etag)]
+        r, status = self.put(self.invoice_id_url, data=data, headers=headers)
+        self.assertValidationErrorStatus(status)
+        expected = ("value '%s' must exist in resource '%s', field '%s'" %
+                    (self.unknown_item_id, 'contacts',
+                     self.app.config['ID_FIELD']))
+        self.assertValidationError(r, {'invoicing_contacts': expected})
+
+        data = {"invoicing_contacts": [self.item_id, self.item_id]}
+        r, status = self.put(self.invoice_id_url, data=data, headers=headers)
+        self.assert200(status)
+        self.assertPutResponse(r, self.invoice_id)
+
     def test_put_write_concern_success(self):
         # 0 and 1 are the only valid values for 'w' on our mongod instance (1
         # is the default)

--- a/eve/tests/test_settings.py
+++ b/eve/tests/test_settings.py
@@ -135,6 +135,10 @@ invoices = {
         'person': {
             'type': 'objectid',
             'data_relation': {'resource': 'contacts'}
+        },
+        'invoicing_contacts': {
+            'type': 'list',
+            'data_relation': {'resource': 'contacts'}
         }
     }
 }


### PR DESCRIPTION
I found that when trying to validate a field attribute with type list I get this error:

```
{
    "_status": "ERR",
    "_issues": {
        "music_type": "value '[u'elem1', u'elem2']' must exist in resource 'types', field 'key'."
    },
    "_error": {
        "message": "Insertion failure: 1 document(s) contain(s) error(s)",
        "code": 400
    }
}
```

I've added support for this type of field attribute.
