### PR TITLE
Add support for multiple origins when using CORS

### DIFF
--- a/eve/render.py
+++ b/eve/render.py
@@ -195,7 +195,8 @@ def _prepare_response(resource, dct, last_modified=None, etag=None,
         methods = app.make_default_options_response().headers.get('allow', '')
 
         if '*' in domains:
-            resp.headers.add('Access-Control-Allow-Origin', '*')
+            resp.headers.add('Access-Control-Allow-Origin', origin)
+            resp.headers.add('Vary', 'Origin')
         elif origin in domains:
             resp.headers.add('Access-Control-Allow-Origin', origin)
         else:

--- a/eve/tests/renders.py
+++ b/eve/tests/renders.py
@@ -124,6 +124,7 @@ class TestRenders(TestBase):
         self.assert200(r.status_code)
         self.assertEqual(r.headers['Access-Control-Allow-Origin'],
                          'http://example.com')
+        self.assertEqual(r.headers['Vary'], 'Origin')
 
         # test that if a list is set for X_DOMAINS, then:
         # 1. only list values are accepted;
@@ -183,6 +184,7 @@ class TestRenders(TestBase):
         self.assert200(r.status_code)
         self.assertEqual(r.headers['Access-Control-Allow-Origin'],
                          'http://example.com')
+        self.assertEqual(r.headers['Vary'], 'Origin')
         for m in methods:
             self.assertTrue(m in r.headers['Access-Control-Allow-Methods'])
 


### PR DESCRIPTION
This pull request adds support for multiple origins when using CORS headers.

Motivation:

I have multiple web sites (multiple domains) that utilize one common Eve API. If I access a resource through the first site, everything is fine, but if I access that same resource through the second site, I gets a CORS HTTP error because the browser has cached the response sent from the first site (`Access-Control-Allow-Origin: site1`.)

The [W3C CORS recommendation page](http://www.w3.org/TR/cors/#resource-implementation) suggests that hosts intending to serve to multiple origins should either return `Access-Control-Allow-Origin: *` or, if the origin is specified in that header, to add a `Vary: Origin` header. I think the easiest option is option #1 and that is what is implemented in this pull request.
