### PR TITLE
[WIP] Replace Flask-PyMongo (fixes #855)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -14,6 +14,7 @@ Patches and Contributions
 - Antonio Lourenco
 - Arnau Orriols
 - Arthur Burkart
+- Artem Kolesnikov
 - Ashley Roach
 - Ben Demaree
 - Bjorn Andersson

--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,19 @@ Here you can see the full list of changes between each Eve release.
 Development
 -----------
 
+New Version
+~~~~~~~~~~~
+
+- Update: Removed Flask-PyMongo dependency.
+  - Config setting ``MONGO_AUTHDBNAME`` renamed into ``MONGO_AUTH_SOURCE``
+  for naming consistency with PyMongo.
+  - Config options ``MONGO_MAX_POOL_SIZE``, ``MONGO_SOCKET_TIMEOUT_MS``,
+  ``MONGO_CONNECT_TIMEOUT_MS``, ``MONGO_REPLICA_SET``,
+  ``MONGO_READ_PREFERENCE`` removed. Use ``MONGO_OPTIONS`` or ``MONGO_URL``
+   instead.
+   - Config options ``MONGO_AUTH_MECHANISM`` and
+   ``MONGO_AUTH_MECHANISM_PROPERTIES`` added.
+
 Version 0.7.3
 ~~~~~~~~~~~~~
 - Dev: use official Alabaster theme instead of custom fork.

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -530,10 +530,6 @@ uppercase.
 ``MONGO_URI``                       A `MongoDB URI`_ which is used in preference
                                     of the other configuration variables.
 
-``MONGO_OPTIONS``                   MongoDB keyword arguments to passed to
-                                    MongoClient class ``__init__``.
-                                    Defaults to ``{'connect': True}``.
-
 ``MONGO_HOST``                      MongoDB server address. Defaults to ``localhost``.
 
 ``MONGO_PORT``                      MongoDB port. Defaults to ``27017``.
@@ -544,30 +540,19 @@ uppercase.
 
 ``MONGO_DBNAME``                    MongoDB database name.
 
-``MONGO_AUTHDBNAME``                MongoDB authorization database name. Defaults to ``None``.
+``MONGO_OPTIONS``                   MongoDB keyword arguments to passed to
+                                    MongoClient class ``__init__``.
+                                    Defaults to ``{'connect': True, 'tz_aware': True, 'appname': 'flask_app_name'}``.
+                                    See `PyMongo mongo_client`_ for reference.
 
-``MONGO_MAX_POOL_SIZE``             The maximum number of idle connections
-                                    maintained in the PyMongo connection pool.
-                                    Default: PyMongo default.
+``MONGO_AUTH_SOURCE``               MongoDB authorization database. Defaults to ``None``.
 
-``MONGO_SOCKET_TIMEOUT_MS``         How long (in milliseconds) a send or
-                                    receive on a socket can take before timing
-                                    out. Default: PyMongo default.
+``MONGO_AUTH_MECHANISM``            MongoDB authentication mechanism.
+                                    See `PyMongo Authentication Mechanisms`_.
+                                    Defaults to ``None``.
 
-``MONGO_CONNECT_TIMEOUT_MS``        How long (in milliseconds) a connection can
-                                    take to be opened before timing out.
-                                    Default: PyMongo default.
-
-``MONGO_REPLICA_SET``               The name of a replica set to connect to;
-                                    this must match the internal name of the
-                                    replica set (as deteremined by the
-                                    `isMaster <http://www.mongodb.org/display/DOCS/Replica+Set+Commands#ReplicaSetCommands-isMaster>`_
-                                    command). Default: ``None``.
-
-``MONGO_READ_PREFERENCE``           Determines how read queries are routed to
-                                    the replica set members. Must be one of the
-                                    constants defined on PyMongo's ReadPreference_,
-                                    or the string names thereof.
+``MONGO_AUTH_MECHANISM_PROPERTIES`` Specify MongoDB extra authentication mechanism properties
+                                    if required. Defaults to ``None``.
 
 ``MONGO_QUERY_BLACKLIST``           A list of Mongo query operators that are not
                                     allowed to be used in resource filters
@@ -1535,3 +1520,5 @@ read access open to the public.
 .. _`PyMongo Aggregation Examples`: http://api.mongodb.org/python/current/examples/aggregation.html#aggregation-framework
 .. _`MongoDB Aggregation Framework`: https://docs.mongodb.org/v3.0/applications/aggregation/
 .. _`PyMongo aggregation defaults`: http://api.mongodb.org/python/current/api/pymongo/collection.html#pymongo.collection.Collection.aggregate
+.. _`PyMongo Authentication Mechanisms`: https://docs.mongodb.com/v3.0/core/authentication-mechanisms/
+.. _`PyMongo mongo_client`: http://api.mongodb.com/python/current/api/pymongo/mongo_client.html

--- a/eve/default_settings.py
+++ b/eve/default_settings.py
@@ -243,9 +243,6 @@ RATE_LIMIT_POST = None
 RATE_LIMIT_PATCH = None
 RATE_LIMIT_DELETE = None
 
-# MONGO defaults
-MONGO_HOST = 'localhost'
-MONGO_PORT = 27017
 # disallow Mongo's javascript queries as they might be vulnerable to injection
 # attacks ('ReDoS' especially), are probably too complex for the average API
 # end-user and finally can  seriously impact overall performance.
@@ -254,7 +251,6 @@ MONGO_QUERY_BLACKLIST = ['$where', '$regex']
 # aknowledged writes). This is also the current PyMongo/Mongo default setting.
 MONGO_WRITE_CONCERN = {'w': 1}
 MONGO_OPTIONS = {
-    'connect': True
+    'connect': True,
+    'tz_aware': True,
 }
-# Compatibility for flask-pymongo.
-MONGO_CONNECT = MONGO_OPTIONS['connect']

--- a/eve/io/mongo/flask_pymongo.py
+++ b/eve/io/mongo/flask_pymongo.py
@@ -1,0 +1,121 @@
+# -*- coding: utf-8 -*-
+
+"""
+    eve.io.mongo.flask_pymongo
+    ~~~~~~~~~~~~~~~~~~~
+
+    Flask extension to create Mongo connection and database based on
+    configuration.
+
+    :copyright: (c) 2017 by Nicola Iarocci.
+    :license: BSD, see LICENSE for more details.
+"""
+
+from flask import current_app
+from pymongo import MongoClient, uri_parser
+
+
+class PyMongo(object):
+    """
+    Creates Mongo connection and database based on Flask configuration.
+    """
+
+    def __init__(self, app, config_prefix='MONGO'):
+        if 'pymongo' not in app.extensions:
+            app.extensions['pymongo'] = {}
+
+        if config_prefix in app.extensions['pymongo']:
+            raise Exception('duplicate config_prefix "%s"' % config_prefix)
+
+        self.config_prefix = config_prefix
+
+        def key(suffix):
+            return '%s_%s' % (config_prefix, suffix)
+
+        def config_to_kwargs(mapping):
+            """
+            Convert config options to kwargs according to provided mapping
+            information.
+            """
+            kwargs = {}
+            for option, arg in mapping.items():
+                if key(option) in app.config:
+                    kwargs[arg] = app.config[key(option)]
+            return kwargs
+
+        app.config.setdefault(key('HOST'), 'localhost')
+        app.config.setdefault(key('PORT'), 27017)
+        app.config.setdefault(key('DBNAME'), app.name)
+        app.config.setdefault(key('WRITE_CONCERN'), {'w': 1})
+        client_kwargs = {
+            'appname': app.name,
+            'connect': True,
+            'tz_aware': True,
+        }
+        if key('OPTIONS') in app.config:
+            client_kwargs.update(app.config[key('OPTIONS')])
+
+        if key('WRITE_CONCERN') in app.config:
+            # w, wtimeout, j and fsync
+            client_kwargs.update(app.config[key('WRITE_CONCERN')])
+
+        uri_parser.validate_options(client_kwargs)
+
+        if key('URI') in app.config:
+            host = app.config[key('URI')]
+            # raises an exception if uri is invalid
+            mongo_settings = uri_parser.parse_uri(host)
+            dbname = mongo_settings.get('database')
+            if not dbname:
+                raise ValueError('MongoDB URI does not contain database name')
+        else:
+            dbname = app.config[key('DBNAME')]
+            host = app.config[key('HOST')]
+            client_kwargs['port'] = app.config[key('PORT')]
+
+        client_kwargs['host'] = host
+
+        if key('DOCUMENT_CLASS') in app.config:
+            client_kwargs['document_class'] = app.config[key('DOCUMENT_CLASS')]
+
+        cx = MongoClient(**client_kwargs)
+        db = cx[dbname]
+
+        if key('USERNAME') in app.config:
+            app.config.setdefault(key('PASSWORD'), None)
+            username = app.config[key('USERNAME')]
+            password = app.config[key('PASSWORD')]
+            auth = (username, password)
+            if any(auth) and not all(auth):
+                raise Exception(
+                    'Must set both USERNAME and PASSWORD or neither')
+            if any(auth):
+                auth_mapping = {
+                    'AUTH_MECHANISM': 'mechanism',
+                    'AUTH_SOURCE': 'source',
+                    'AUTH_MECHANISM_PROPERTIES': 'authMechanismProperties',
+                }
+                auth_kwargs = config_to_kwargs(auth_mapping)
+                db.authenticate(username, password, **auth_kwargs)
+
+        app.extensions['pymongo'][config_prefix] = (cx, db)
+
+    @property
+    def cx(self):
+        """
+        Automatically created :class:`~pymongo.Connection` object corresponding
+        to the provided configuration parameters.
+        """
+        if self.config_prefix not in current_app.extensions['pymongo']:
+            raise Exception('flask_pymongo extensions is not initialized')
+        return current_app.extensions['pymongo'][self.config_prefix][0]
+
+    @property
+    def db(self):
+        """
+        Automatically created :class:`~pymongo.Database` object
+        corresponding to the provided configuration parameters.
+        """
+        if self.config_prefix not in current_app.extensions['pymongo']:
+            raise Exception('flask_pymongo extensions is not initialized')
+        return current_app.extensions['pymongo'][self.config_prefix][1]

--- a/eve/io/mongo/mongo.py
+++ b/eve/io/mongo/mongo.py
@@ -19,7 +19,7 @@ from bson import ObjectId
 from bson.dbref import DBRef
 from copy import copy
 from flask import abort, request, g
-from flask_pymongo import PyMongo
+from .flask_pymongo import PyMongo
 from pymongo import WriteConcern
 from werkzeug.exceptions import HTTPException
 

--- a/eve/tests/__init__.py
+++ b/eve/tests/__init__.py
@@ -7,7 +7,7 @@ import random
 import os
 import simplejson as json
 from datetime import datetime, timedelta
-from flask_pymongo import MongoClient
+from pymongo import MongoClient
 from bson import ObjectId
 from eve.tests.test_settings import MONGO_PASSWORD, MONGO_USERNAME, \
     MONGO_DBNAME, DOMAIN, MONGO_HOST, MONGO_PORT

--- a/eve/tests/io/flask_pymongo.py
+++ b/eve/tests/io/flask_pymongo.py
@@ -1,0 +1,69 @@
+from eve.tests import TestBase
+from pymongo import MongoClient
+from pymongo.errors import OperationFailure
+from eve.tests.test_settings import MONGO1_DBNAME, MONGO1_USERNAME, \
+    MONGO1_PASSWORD, MONGO_HOST, MONGO_PORT
+from eve.io.mongo.flask_pymongo import PyMongo
+
+
+class TestPyMongo(TestBase):
+    def setUp(self, url_converters=None):
+        super(TestPyMongo, self).setUp(url_converters)
+        self._setupdb()
+        schema = {
+            'title': {'type': 'string'},
+        }
+        settings = {
+            'schema': schema,
+            'mongo_prefix': 'MONGO1',
+        }
+
+        self.app.register_resource('works', settings)
+
+    def test_auth_params_provided_in_mongo_url(self):
+        self.app.config['MONGO1_URL'] = \
+            'mongodb://%s:%s@%s:%s' % (MONGO1_USERNAME, MONGO1_PASSWORD,
+                                       MONGO_HOST, MONGO_PORT)
+        with self.app.app_context():
+            db = PyMongo(self.app, 'MONGO1').db
+        self.assertEquals(0, db.works.count())
+
+    def test_auth_params_provided_in_config(self):
+        self.app.config['MONGO1_USERNAME'] = MONGO1_USERNAME
+        self.app.config['MONGO1_PASSWORD'] = MONGO1_PASSWORD
+        with self.app.app_context():
+            db = PyMongo(self.app, 'MONGO1').db
+        self.assertEquals(0, db.works.count())
+
+    def test_invalid_auth_params_provided(self):
+        # if bad username and/or password is provided in MONGO_URL and mongo
+        # run w\o --auth pymongo won't raise exception
+        self.app.config['MONGO1_USERNAME'] = 'bad_username'
+        self.app.config['MONGO1_PASSWORD'] = 'bad_password'
+        self.assertRaises(OperationFailure, self._pymongo_instance)
+
+    def test_invalid_port(self):
+        self.app.config['MONGO1_PORT'] = 'bad_value'
+        self.assertRaises(TypeError, self._pymongo_instance)
+
+    def test_invalid_options(self):
+        self.app.config['MONGO1_OPTIONS'] = {
+            'connectTimeoutMS': 'bad_value'
+        }
+        self.assertRaises(ValueError, self._pymongo_instance)
+
+    def test_valid_port(self):
+        self.app.config['MONGO1_PORT'] = 27017
+        with self.app.app_context():
+            db = PyMongo(self.app, 'MONGO1').db
+        self.assertEquals(0, db.works.count())
+
+    def _setupdb(self):
+        self.connection = MongoClient()
+        self.connection.drop_database(MONGO1_DBNAME)
+        self.connection[MONGO1_DBNAME].add_user(MONGO1_USERNAME,
+                                                MONGO1_PASSWORD)
+
+    def _pymongo_instance(self):
+        with self.app.app_context():
+            PyMongo(self.app, 'MONGO1')

--- a/eve/tests/io/multi_mongo.py
+++ b/eve/tests/io/multi_mongo.py
@@ -3,7 +3,7 @@ from datetime import datetime
 
 import json
 from bson import ObjectId
-from flask_pymongo import MongoClient
+from pymongo import MongoClient
 
 import eve
 from eve.auth import BasicAuth

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 Cerberus==0.9.2
 Events==0.2.1
-Flask-PyMongo==0.4.1
 Flask==0.12
 itsdangerous==0.24
 Jinja2==2.9.4


### PR DESCRIPTION
This is _work in progress_ PR.

Flask-PyMongo is abandoned and is not compatible with latests PyMongo version.
This PR removes this dependency in Eve framewrok.

TODO:

- [x] priority for auth parameters if specified both in MONGO_URL and MONGO_AUTH params. 
- [x] pymongo kwargs validation
- [x] tests for flask_pymongo module
- [x] new tests for authentication
- [x] fix CI tests
- [x] Decide what to do with MONGO_OPTIONS
- [x] documentation

Hey @nicolaiarocci Could you please review this PR and let me know if I moving into right direction. 

Feel free to add stuff in TODO if any.