### PR TITLE
Bulk delete

### DIFF
--- a/eve/io/base.py
+++ b/eve/io/base.py
@@ -175,13 +175,14 @@ class DataLayer(object):
         """
         raise NotImplementedError
 
-    def find_one_raw(self, resource, _id):
-        """ Retrieves a single, raw document. No projections or datasource
-        filters are being applied here. Just looking up the document by unique
-        id.
 
-        :param resource: resource name.
-        :param id: unique id.
+    def find_one_raw(self, resource, **lookup):
+        """ Retrieves a single, raw document. No projections or datasource
+        filters are being applied here. Just looking up the document using the same lookup.
+
+        :param
+        resource: resource name.
+        :param ** lookup: lookup query.
 
         .. versionadded:: 0.4
         """
@@ -249,7 +250,7 @@ class DataLayer(object):
         """
         raise NotImplementedError
 
-    def remove(self, resource, lookup={}):
+    def remove(self, resource, lookup):
         """ Removes a document/row or an entire set of documents/rows from a
         database collection/table.
 

--- a/eve/io/mongo/mongo.py
+++ b/eve/io/mongo/mongo.py
@@ -311,15 +311,14 @@ class Mongo(DataLayer):
             filter_ = self.combine_queries(
                 filter_, {config.DELETED: {"$ne": True}})
 
-        document = self.pymongo(resource).db[datasource] \
-                                         .find_one(filter_, projection)
-        return document
+        return self.pymongo(resource).db[datasource] \
+                                     .find_one(filter_, projection)
 
-    def find_one_raw(self, resource, _id):
+    def find_one_raw(self, resource, **lookup):
         """ Retrieves a single raw document.
 
         :param resource: resource name.
-        :param id: unique id.
+        :param **lookup: lookup query.
 
         .. versionchanged:: 0.6
            Support for multiple databases.
@@ -327,12 +326,14 @@ class Mongo(DataLayer):
         .. versionadded:: 0.4
         """
         id_field = config.DOMAIN[resource]['id_field']
+        _id = lookup.get(id_field)
         datasource, filter_, _, _ = self._datasource_ex(resource,
                                                         {id_field: _id},
                                                         None)
 
-        document = self.pymongo(resource).db[datasource].find_one(_id)
-        return document
+        lookup = self._mongotize(lookup, resource)
+
+        return self.pymongo(resource).db[datasource].find_one(lookup)
 
     def find_list_of_ids(self, resource, ids, client_projection=None):
         """ Retrieves a list of documents from the collection given

--- a/eve/methods/common.py
+++ b/eve/methods/common.py
@@ -33,7 +33,7 @@ from functools import wraps
 from werkzeug.datastructures import MultiDict, CombinedMultiDict
 
 
-def get_document(resource, concurrency_check, **lookup):
+def get_document(resource, concurrency_check, original=None, **lookup):
     """ Retrieves and return a single document. Since this function is used by
     the editing methods (PUT, PATCH, DELETE), we make sure that the client
     request references the current representation of the document before
@@ -43,6 +43,7 @@ def get_document(resource, concurrency_check, **lookup):
 
     :param resource: the name of the resource to which the document belongs to.
     :param concurrency_check: boolean check for concurrency control
+    :param original: in case the document was already retrieved before
     :param **lookup: document lookup query
 
     .. versionchanged:: 0.6
@@ -65,7 +66,11 @@ def get_document(resource, concurrency_check, **lookup):
         # callers must handle soft deleted documents
         req.show_deleted = True
 
-    document = app.data.find_one(resource, req, **lookup)
+    if original:
+        document = original
+    else:
+        document = app.data.find_one(resource, req, **lookup)
+
     if document:
         e_if_m = config.ENFORCE_IF_MATCH
         if_m = config.IF_MATCH

--- a/eve/tests/__init__.py
+++ b/eve/tests/__init__.py
@@ -426,6 +426,14 @@ class TestBase(TestMinimal):
 
         self.epoch = date_to_str(datetime(1970, 1, 1))
 
+        self.products = 'products'
+        self.products_url = ('/%s' %
+                             self.domain[self.products]['url'])
+
+        self.child_products = 'child_products'
+        self.child_products_url = ('/%s' %
+                                   self.domain[self.child_products]['url'])
+
     def response_item(self, response, i=0):
         if self.app.config['HATEOAS']:
             return response['_items'][i]
@@ -539,6 +547,13 @@ class TestBase(TestMinimal):
             transactions.append(transaction)
         return transactions
 
+    def generate_products(self):
+        products = self.random_products(10)
+        skus = [product['sku'] for product in products]
+        for counter, sku in enumerate(skus[5:], 0):
+            products[counter]['parent_product'] = sku
+        return products
+
     def bulk_insert(self):
         _db = self.connection[MONGO_DBNAME]
         _db.contacts.insert(self.random_contacts(self.known_resource_count))
@@ -546,5 +561,6 @@ class TestBase(TestMinimal):
         _db.payments.insert(self.random_payments(10))
         _db.invoices.insert(self.random_invoices(1))
         _db.internal_transactions.insert(self.random_internal_transactions(4))
-        _db.products.insert(self.random_products(2))
+        products = self.generate_products()
+        _db.products.insert(products)
         self.connection.close()

--- a/eve/tests/methods/get.py
+++ b/eve/tests/methods/get.py
@@ -1113,7 +1113,7 @@ class TestGet(TestBase):
         self.assertHomeLink(links)
         self.assertResourceLink(links, 'products')
         items = response['_items']
-        self.assertEqual(2, len(items))
+        self.assertEqual(10, len(items))
         for item in items:
             self.assertItem(item, 'products')
 


### PR DESCRIPTION
Bulk delete fix +Adding callback on the bulk delete flow for customization purpose

Issue #1028 
Issue #1010 --> to support the possibility to perform a bulk delete with a multi key unique id (Note: only for not soft delete, as per soft delete is possible to achieve it with customisation in the datalayer)