### PR TITLE
Fix #1036 : allow to define mixed projections

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -156,3 +156,4 @@ Patches and Contributions
 - dccrazyboy
 - mmizotin
 - xgdgsc
+- Hugo Larcher

--- a/eve/io/base.py
+++ b/eve/io/base.py
@@ -439,6 +439,11 @@ class DataLayer(object):
                 # there's no standard projection so we assume we are in a
                 # allow_unknown = True
                 fields = client_projection
+        elif projection_ is not None:
+            # in case of mixed projection, only keep the exclusions
+            projection_vals = projection_.values()
+            if 0 in projection_vals and 1 in projection_vals:
+                fields = dict((k, v) for k, v in projection_.items() if not v)
 
         # If the current HTTP method is in `public_methods` or
         # `public_item_methods`, skip the `auth_field` check


### PR DESCRIPTION
The purpose of this PR is to fix the #1036 issue by allowing mixed projections. Mixed projections can be defined as default projection so that fields can be hidden by default and still requested in projections.
The use case is to reduce the amount of data sent by the API by hiding less used/data-extensive fields.