### PR TITLE
Fix a serialization bug that randomly skips fields if "x_of" is encountered

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -125,6 +125,7 @@ Patches and Contributions
 - Petr Jašek
 - Prayag Verma
 - Ralph Smith
+- Raychee
 - Robert Wlodarczyk
 - Roberto 'Kalamun' Pasini
 - Rodrigo Rodriguez


### PR DESCRIPTION
The purpose of this PR is to make sure all of the fields are correctly serialized when there are ```x_of``` validation rules.

The tricky part of this bug is that it is not stably repeatable. This is because the serialization iterates through the json keys in random order, and the bug shows up only when the fields that contain ```x_of``` rules are processed **before** other fields. In short, the ```schema``` variable in function ```serialize``` will be overwritten mistakenly in ```if x_of``` clause, causing the serialization of the rest of the fields are skipped, due to the ill-formed ```schema```.

Along with this bug fix, the PR also enabled correct serialization under circumstances where ```x_of``` appears at the first level of a field's schema whose type is list.

Two new unit test cases are written for these scenarios, and one of them uses ```OrderedDict``` to guarantee the traversing order of the json keys.

(This is a repost of PR #1040. Please let me know if there are other improvements I need to make.)