### PR TITLE
Add support to the bitwise query operator.

### DIFF
--- a/eve/io/mongo/mongo.py
+++ b/eve/io/mongo/mongo.py
@@ -105,7 +105,8 @@ class Mongo(DataLayer):
         ['$options', '$search', '$language'] +
         ['$exists', '$type'] +
         ['$geoWithin', '$geoIntersects', '$near', '$nearSphere'] +
-        ['$all', '$elemMatch', '$size']
+        ['$all', '$elemMatch', '$size'] + 
+        ['$bitsAllClear', '$bitsAllSet', '$bitsAnyClear', '$bitsAnySet']
     )
 
     def init_app(self, app):


### PR DESCRIPTION
Bitwise query operator e.g., `$bitsAllClear` can be useful for query over number. However, `eve` doesn't support it yet. This PR add the supports of bitwise query operator.