### PR TITLE
use OrderedDict from backport_collections

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -22,6 +22,7 @@ Patches and Contributions
 - Brad P. Crochet
 - Brian Mego
 - Bryan Cattle
+- Carl George
 - Carles Bruguera
 - Christian Henke
 - Christoph Witzany

--- a/eve/render.py
+++ b/eve/render.py
@@ -25,7 +25,7 @@ try:
     from collections import OrderedDict  # noqa
 except ImportError:
     # Python 2.6 needs this back-port
-    from ordereddict import OrderedDict
+    from backport_collections import OrderedDict
 
 # mapping between supported mime types and render functions.
 _MIME_TYPES = [

--- a/eve/tests/methods/common.py
+++ b/eve/tests/methods/common.py
@@ -15,7 +15,7 @@ try:
     from collections import OrderedDict  # noqa
 except ImportError:
     # Python 2.6 needs this back-port
-    from ordereddict import OrderedDict
+    from backport_collections import OrderedDict
 
 
 class TestSerializer(TestBase):

--- a/py26-requirements.txt
+++ b/py26-requirements.txt
@@ -1,2 +1,2 @@
 -r requirements.txt
-ordereddict
+backport_collections==0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,3 @@ MarkupSafe==0.23
 pymongo==3.5.0
 simplejson==3.8.2
 Werkzeug==0.11.15
-backport_collections==0.1

--- a/setup.py
+++ b/setup.py
@@ -15,14 +15,13 @@ install_requires = [
     'itsdangerous>=0.24,<1.0',
     'flask>=0.10.1,<=0.12',
     'pymongo>=3.5',
-    'backport_collections>=0.1',
 ]
 
 try:
-    from collections import OrderedDict  # noqa
+    from collections import Counter, OrderedDict  # noqa
 except ImportError:
-    # Python 2.6 needs this back-port
-    install_requires.append('ordereddict')
+    # Python 2.6
+    install_requires.append('backport_collections')
 
 
 setup(


### PR DESCRIPTION
It is unnecessary to require the ordereddict module because the backport_collections module already has the OrderedDict class.  This change removes the ordereddict dependency, and also ensures that backport_collections is only required when needed.