### PR TITLE
Fix sanitization of nested queries.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -107,6 +107,7 @@ Patches and Contributions
 - Mattias Lundberg
 - Mayur Dhamanwala
 - Mikael Berg
+- Moritz Schneider
 - Mugur Rus
 - Nathan Reynolds
 - Niall Donegan

--- a/eve/io/mongo/mongo.py
+++ b/eve/io/mongo/mongo.py
@@ -817,10 +817,14 @@ class Mongo(DataLayer):
                     'Query contains operators banned in MONGO_QUERY_BLACKLIST'
                 ))
 
-        sanitize_keys(spec)
-        for value in spec.values():
-            if isinstance(value, dict):
-                sanitize_keys(value)
+        if isinstance(spec, dict):
+            sanitize_keys(spec)
+            for value in spec.values():
+                self._sanitize(value)
+        if isinstance(spec, list):
+            for value in spec:
+                self._sanitize(value)
+
         return spec
 
     def _wc(self, resource):

--- a/eve/tests/methods/get.py
+++ b/eve/tests/methods/get.py
@@ -205,6 +205,15 @@ class TestGet(TestBase):
         _, status = self.get(self.known_resource, '?where=%s' % where)
         self.assert400(status)
 
+    def test_get_mongo_query_blacklist_nested(self):
+        where = '{"$or": [{"$where": "this.ref == ''%s''"}]}' % self.item_name
+        _, status = self.get(self.known_resource, '?where=%s' % where)
+        self.assert400(status)
+
+        where = '{"$or": [{"ref": {"$regex": "%s"}}]}' % self.item_name
+        _, status = self.get(self.known_resource, '?where=%s' % where)
+        self.assert400(status)
+
     def test_get_where_mongo_objectid_as_string(self):
         where = '{"tid": "%s"}' % self.item_tid
         response, status = self.get(self.known_resource, '?where=%s' % where)


### PR DESCRIPTION
A query was not fully traversed in the sanitization. Therefore the blacklist for mongo wueries could be bypassed, allowing for dangerous "$where" queries.