### PR TITLE
Renderer classes

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -94,6 +94,7 @@ Patches and Contributions
 - Mandar Vaze
 - Manquer
 - Marc Abramowitz
+- Marcin Puhacz
 - Marcus Cobden
 - Marica Odagaki
 - Mario Kralj

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -453,7 +453,6 @@ uppercase.
 
 ``META``                            Allows to customize the meta field. Defaults
                                     to ``_meta``
-                                    to ``_meta``.
 
 ``INFO``                            String value to include an info section, with the
                                     given INFO name, at the Eve homepage (suggested
@@ -474,15 +473,9 @@ uppercase.
 
 ``ENFORCE_IF_MATCH``                ``True`` to always enforce concurrency control when
                                     it is enabled, ``False`` otherwise. Defaults to
-                                    ``True``. See :ref:`concurrency`.
 
-``XML``                             ``True`` to enable XML support, ``False``
-                                    otherwise. See :ref:`jsonxml`. Defaults to
-                                    ``True``.
-
-``JSON``                            ``True`` to enable JSON support, ``False``
-                                    otherwise. See :ref:`jsonxml`. Defaults to
-                                    ``True``.
+``RENDERERS``                       Allows to change enabled renderers. Defaults to
+                                    ``['eve.render.JSONRenderer', 'eve.render.XMLRenderer']``.
 
 ``JSON_SORT_KEYS``                  ``True`` to enable JSON key sorting, ``False``
                                     otherwise. Defaults to ``False``.

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -473,6 +473,7 @@ uppercase.
 
 ``ENFORCE_IF_MATCH``                ``True`` to always enforce concurrency control when
                                     it is enabled, ``False`` otherwise. Defaults to
+                                    ``True``. See :ref:`concurrency`.
 
 ``RENDERERS``                       Allows to change enabled renderers. Defaults to
                                     ``['eve.render.JSONRenderer', 'eve.render.XMLRenderer']``.

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -488,9 +488,9 @@ want to turn HATEOAS off? Well, if you know that your client application is not
 going to use the feature, then you might want to save on both bandwidth and
 performance.
 
-.. _jsonxml:
+.. _rendering:
 
-JSON and XML Rendering
+Rendering
 ----------------------
 Eve responses are automatically rendered as JSON (the default) or XML,
 depending on the request ``Accept`` header. Inbound documents (for inserts and
@@ -510,10 +510,18 @@ edits) are in JSON format.
         <link rel="child" href="works" title="works" />
     </resource>
 
-XML support can be disabled by setting ``XML`` to ``False`` in the settings
-file. JSON support can be disabled by setting ``JSON`` to ``False``.  Please
-note that at least one mime type must always be enabled, either implicitly or
-explicitly. By default, both are supported.
+Default renderers might be changed by editing ``RENDERERS`` value in the settings file.
+
+.. code-block:: python
+
+    RENDERERS = [
+        'eve.render.JSONRenderer',
+        'eve.render.XMLRenderer'
+    ]
+
+You can create your own renderer by subclassing ``eve.render.Renderer``. Each
+renderer should set valid ``mime`` attr and have ``.render()`` method implemented.
+Please note that at least one renderer must always be enabled.
 
 .. _conditional_requests:
 

--- a/eve/default_settings.py
+++ b/eve/default_settings.py
@@ -11,6 +11,11 @@
     :copyright: (c) 2017 by Nicola Iarocci.
     :license: BSD, see LICENSE for more details.
 
+    .. versionchanged:: 0.8
+        'RENDERERS' added with XML and JSON renderers.
+        'JSON' removed.
+        'XML' removed.
+
     .. versionchanged:: 0.7
        'OPTIMIZE_PAGINATION_FOR_SPEED' added and set to False.
        'OPLOG_RETURN_EXTRA_FIELD' added and set to False.

--- a/eve/default_settings.py
+++ b/eve/default_settings.py
@@ -152,10 +152,10 @@ ALLOWED_FILTERS = ['*']         # filtering enabled by default
 VALIDATE_FILTERS = False
 SORTING = True                  # sorting enabled by default.
 JSON_SORT_KEYS = False          # json key sorting
-RENDERERS = (
+RENDERERS = [
     'eve.render.JSONRenderer',
     'eve.render.XMLRenderer'
-)
+]
 EMBEDDING = True                # embedding enabled by default
 PROJECTION = True               # projection enabled by default
 PAGINATION = True               # pagination enabled by default.

--- a/eve/default_settings.py
+++ b/eve/default_settings.py
@@ -152,6 +152,10 @@ ALLOWED_FILTERS = ['*']         # filtering enabled by default
 VALIDATE_FILTERS = False
 SORTING = True                  # sorting enabled by default.
 JSON_SORT_KEYS = False          # json key sorting
+RENDERERS = (
+    'eve.render.JSONRenderer',
+    'eve.render.XMLRenderer'
+)
 EMBEDDING = True                # embedding enabled by default
 PROJECTION = True               # projection enabled by default
 PAGINATION = True               # pagination enabled by default.

--- a/eve/flaskapp.py
+++ b/eve/flaskapp.py
@@ -265,12 +265,12 @@ class Eve(Flask, Events):
         self.check_deprecated_features()
 
     def check_deprecated_features(self):
-        """ Method check for usage of deprecated features.
+        """ Method checks for usage of deprecated features.
         """
 
         def deprecated_renderers_settings():
             """ Checks if JSON or XML setting is still being used instead of
-            RENDERERS and if so, compose new settings.
+            RENDERERS and if so, composes new settings.
             """
             msg = '{} setting is deprecated and will be removed' \
                   ' in future release. Please use RENDERERS instead.'

--- a/eve/render.py
+++ b/eve/render.py
@@ -301,8 +301,8 @@ class JSONRenderer(Renderer):
         :param data: the data stream to be rendered as json.
 
         .. versionchanged:: 0.2
-           Json encoder class is now inferred by the active data layer, allowing
-           for customized, data-aware JSON encoding.
+           Json encoder class is now inferred by the active data layer,
+           allowing for customized, data-aware JSON encoding.
 
         .. versionchanged:: 0.1.0
            Support for optional HATEOAS.

--- a/eve/render.py
+++ b/eve/render.py
@@ -256,6 +256,10 @@ def _best_mime():
     ones supported by Eve. Along with the mime, also the corresponding
     render function is returns.
 
+    .. versionchanged:: 0.8
+       Support for optional renderers via RENDERERS. XML and JSON
+       configuration keywords removed.
+
     .. versionchanged:: 0.3
        Support for optional renderers via XML and JSON configuration keywords.
     """
@@ -278,8 +282,8 @@ def _best_mime():
 
 
 class Renderer(object):
-    """ Base class for all the renderers. Renderer should set valid `mime` attr
-    and have `.render()` method implemented.
+    """ Base class for all the renderers. Renderer should set valid `mime`
+    attr and have `.render()` method implemented.
 
     """
     mime = tuple()
@@ -290,7 +294,7 @@ class Renderer(object):
 
 
 class JSONRenderer(Renderer):
-    """ JSON renderer class
+    """ JSON renderer class based on `simplejson` package.
 
     """
     mime = ('application/json',)
@@ -318,7 +322,7 @@ class JSONRenderer(Renderer):
 
 
 class XMLRenderer(Renderer):
-    """ XML renderer class
+    """ XML renderer class.
 
     """
     mime = ('application/xml', 'text/xml', 'application/x-xml',)

--- a/eve/render.py
+++ b/eve/render.py
@@ -18,7 +18,7 @@ from werkzeug import utils
 from functools import wraps
 from eve.methods.common import get_rate_limit
 from eve.utils import date_to_str, date_to_rfc1123, config, \
-    debug_error_message
+    debug_error_message, import_from_string
 from flask import make_response, request, Response, current_app as app, abort
 
 try:
@@ -26,12 +26,6 @@ try:
 except ImportError:
     # Python 2.6 needs this back-port
     from backport_collections import OrderedDict
-
-# mapping between supported mime types and render functions.
-_MIME_TYPES = [
-    {'mime': ('application/json',), 'renderer': 'render_json', 'tag': 'JSON'},
-    {'mime': ('application/xml', 'text/xml', 'application/x-xml',),
-     'renderer': 'render_xml', 'tag': 'XML'}]
 
 
 def raise_event(f):
@@ -144,10 +138,10 @@ def _prepare_response(resource, dct, last_modified=None, etag=None,
     else:
         # obtain the best match between client's request and available mime
         # types, along with the corresponding render function.
-        mime, renderer = _best_mime()
+        mime, renderer_cls = _best_mime()
 
         # invoke the render function and obtain the corresponding rendered item
-        rendered = globals()[renderer](dct)
+        rendered = renderer_cls().render(dct)
 
         # JSONP
         if config.JSONP_ARGUMENT:
@@ -267,12 +261,11 @@ def _best_mime():
     """
     supported = []
     renders = {}
-    for mime in _MIME_TYPES:
-        # only mime types that have not been disabled via configuration
-        if app.config.get(mime['tag'], True):
-            for mime_type in mime['mime']:
-                supported.append(mime_type)
-                renders[mime_type] = mime['renderer']
+    for renderer_cls in app.config.get('RENDERERS'):
+        renderer = import_from_string(renderer_cls)
+        for mime_type in renderer.mime:
+            supported.append(mime_type)
+            renders[mime_type] = renderer
 
     if len(supported) == 0:
         abort(500, description=debug_error_message(
@@ -284,197 +277,227 @@ def _best_mime():
     return best_match, renders[best_match]
 
 
-def render_json(data):
-    """ JSON render function
+class Renderer(object):
+    """ Base class for all the renderers. Renderer should set valid `mime` attr
+    and have `.render()` method implemented.
 
-    .. versionchanged:: 0.2
-       Json encoder class is now inferred by the active data layer, allowing
-       for customized, data-aware JSON encoding.
-
-    .. versionchanged:: 0.1.0
-       Support for optional HATEOAS.
     """
-    set_indent = None
+    mime = tuple()
 
-    # make pretty prints available
-    if 'GET' in request.method and 'pretty' in request.args:
-        set_indent = 4
-    return json.dumps(data, indent=set_indent, cls=app.data.json_encoder_class,
-                      sort_keys=config.JSON_SORT_KEYS)
+    def render(self, data):
+        raise NotImplementedError('Renderer .render() method is not '
+                                  'implemented')
 
 
-def render_xml(data):
-    """ XML render function.
+class JSONRenderer(Renderer):
+    """ JSON renderer class
 
-    :param data: the data stream to be rendered as xml.
-
-    .. versionchanged:: 0.4
-       Support for pagination info (_meta).
-
-    .. versionchanged:: 0.2
-       Use the new ITEMS configuration setting.
-
-    .. versionchanged:: 0.1.0
-       Support for optional HATEOAS.
-
-    .. versionchanged:: 0.0.3
-       Support for HAL-like hyperlinks and resource descriptors.
     """
-    if isinstance(data, list):
-        data = {config.ITEMS: data}
+    mime = ('application/json',)
 
-    xml = ''
-    if data:
-        xml += xml_root_open(data)
-        xml += xml_add_links(data)
-        xml += xml_add_meta(data)
-        xml += xml_add_items(data)
-        xml += xml_root_close()
-    return xml
+    def render(self, data):
+        """ JSON render function
+
+        :param data: the data stream to be rendered as json.
+
+        .. versionchanged:: 0.2
+           Json encoder class is now inferred by the active data layer, allowing
+           for customized, data-aware JSON encoding.
+
+        .. versionchanged:: 0.1.0
+           Support for optional HATEOAS.
+        """
+        set_indent = None
+
+        # make pretty prints available
+        if 'GET' in request.method and 'pretty' in request.args:
+            set_indent = 4
+        return json.dumps(data, indent=set_indent,
+                          cls=app.data.json_encoder_class,
+                          sort_keys=config.JSON_SORT_KEYS)
 
 
-def xml_root_open(data):
-    """ Returns the opening tag for the XML root node. If the datastream
-    includes informations about resource endpoints (href, title), they will
-    be added as node attributes. The resource endpoint is then removed to allow
-    for further processing of the datastream.
+class XMLRenderer(Renderer):
+    """ XML renderer class
 
-    :param data: the data stream to be rendered as xml.
-
-    .. versionchanged:: 0.1.0
-       Support for optional HATEOAS.
-
-    .. versionchanged:: 0.0.6
-       Links are now properly escaped.
-
-    .. versionadded:: 0.0.3
     """
-    links = data.get(config.LINKS)
-    href = title = ''
-    if links and 'self' in links:
-        self_ = links.pop('self')
-        href = ' href="%s" ' % utils.escape(self_['href'])
-        if 'title' in self_:
-            title = ' title="%s" ' % self_['title']
-    return '<resource%s%s>' % (href, title)
+    mime = ('application/xml', 'text/xml', 'application/x-xml',)
+    tag = 'XML'
 
+    def render(self, data):
+        """ XML render function.
 
-def xml_add_meta(data):
-    """ Returns a meta node with page, total, max_results fields.
+        :param data: the data stream to be rendered as xml.
 
-    :param data: the data stream to be rendered as xml.
+        .. versionchanged:: 0.4
+           Support for pagination info (_meta).
 
-    .. versionchanged:: 0.5
-       Always return ordered items (#441).
+        .. versionchanged:: 0.2
+           Use the new ITEMS configuration setting.
 
-    .. versionadded:: 0.4
-    """
-    xml = ''
-    meta = []
-    if data.get(config.META):
-        ordered_meta = OrderedDict(sorted(data[config.META].items()))
-        for name, value in ordered_meta.items():
-            meta.append('<%s>%d</%s>' % (name, value, name))
-    if meta:
-        xml = '<%s>%s</%s>' % (config.META, ''.join(meta), config.META)
-    return xml
+        .. versionchanged:: 0.1.0
+           Support for optional HATEOAS.
 
+        .. versionchanged:: 0.0.3
+           Support for HAL-like hyperlinks and resource descriptors.
+        """
+        if isinstance(data, list):
+            data = {config.ITEMS: data}
 
-def xml_add_links(data):
-    """ Returns as many <link> nodes as there are in the datastream. The links
-    are then removed from the datastream to allow for further processing.
+        xml = ''
+        if data:
+            xml += self.xml_root_open(data)
+            xml += self.xml_add_links(data)
+            xml += self.xml_add_meta(data)
+            xml += self.xml_add_items(data)
+            xml += self.xml_root_close()
+        return xml
 
-    :param data: the data stream to be rendered as xml.
+    @classmethod
+    def xml_root_open(cls, data):
+        """ Returns the opening tag for the XML root node. If the datastream
+        includes informations about resource endpoints (href, title), they will
+        be added as node attributes. The resource endpoint is then removed to
+        allow for further processing of the datastream.
 
-    .. versionchanged:: 0.5
-       Always return ordered items (#441).
+        :param data: the data stream to be rendered as xml.
 
-    .. versionchanged:: 0.0.6
-       Links are now properly escaped.
+        .. versionchanged:: 0.1.0
+           Support for optional HATEOAS.
 
-    .. versionadded:: 0.0.3
-    """
-    xml = ''
-    chunk = '<link rel="%s" href="%s" title="%s" />'
-    links = data.pop(config.LINKS, {})
-    ordered_links = OrderedDict(sorted(links.items()))
-    for rel, link in ordered_links.items():
-        if isinstance(link, list):
-            xml += ''.join([chunk % (rel, utils.escape(d['href']),
-                                     utils.escape(d['title'])) for d in link])
-        else:
-            xml += ''.join(chunk % (rel, utils.escape(link['href']),
-                                    link['title']))
-    return xml
+        .. versionchanged:: 0.0.6
+           Links are now properly escaped.
 
+        .. versionadded:: 0.0.3
+        """
+        links = data.get(config.LINKS)
+        href = title = ''
+        if links and 'self' in links:
+            self_ = links.pop('self')
+            href = ' href="%s" ' % utils.escape(self_['href'])
+            if 'title' in self_:
+                title = ' title="%s" ' % self_['title']
+        return '<resource%s%s>' % (href, title)
 
-def xml_add_items(data):
-    """ When this function is called the datastream can only contain a `_items`
-    list, or a dictionary. If a list, each item is a resource which rendered as
-    XML. If a dictionary, it will be rendered as XML.
+    @classmethod
+    def xml_add_meta(cls, data):
+        """ Returns a meta node with page, total, max_results fields.
 
-    :param data: the data stream to be rendered as xml.
+        :param data: the data stream to be rendered as xml.
 
-    .. versionadded:: 0.0.3
-    """
-    try:
-        xml = ''.join([xml_item(item) for item in data[config.ITEMS]])
-    except:
-        xml = xml_dict(data)
-    return xml
+        .. versionchanged:: 0.5
+           Always return ordered items (#441).
 
+        .. versionadded:: 0.4
+        """
+        xml = ''
+        meta = []
+        if data.get(config.META):
+            ordered_meta = OrderedDict(sorted(data[config.META].items()))
+            for name, value in ordered_meta.items():
+                meta.append('<%s>%d</%s>' % (name, value, name))
+        if meta:
+            xml = '<%s>%s</%s>' % (config.META, ''.join(meta), config.META)
+        return xml
 
-def xml_item(item):
-    """ Represents a single resource (member of a collection) as XML.
+    @classmethod
+    def xml_add_links(cls, data):
+        """ Returns as many <link> nodes as there are in the datastream. The
+        links are then removed from the datastream to allow for further
+        processing.
 
-    :param data: the data stream to be rendered as xml.
+        :param data: the data stream to be rendered as xml.
 
-    .. versionadded:: 0.0.3
-    """
-    xml = xml_root_open(item)
-    xml += xml_add_links(item)
-    xml += xml_dict(item)
-    xml += xml_root_close()
-    return xml
+        .. versionchanged:: 0.5
+           Always return ordered items (#441).
 
+        .. versionchanged:: 0.0.6
+           Links are now properly escaped.
 
-def xml_root_close():
-    """ Returns the closing tag of the XML root node.
-
-    .. versionadded:: 0.0.3
-    """
-    return '</resource>'
-
-
-def xml_dict(data):
-    """ Renders a dict as XML.
-
-    :param data: the data stream to be rendered as xml.
-
-    .. versionchanged:: 0.5
-       Always return ordered items (#441).
-
-    .. versionchanged:: 0.2
-       Leaf values are now properly escaped.
-
-    .. versionadded:: 0.0.3
-    """
-    xml = ''
-    ordered_items = OrderedDict(sorted(data.items()))
-    for k, v in ordered_items.items():
-        if isinstance(v, datetime.datetime):
-            v = date_to_str(v)
-        elif isinstance(v, (datetime.time, datetime.date)):
-            v = v.isoformat()
-        if not isinstance(v, list):
-            v = [v]
-        for value in v:
-            if isinstance(value, dict):
-                links = xml_add_links(value)
-                xml += "<%s>" % k
-                xml += xml_dict(value)
-                xml += links
-                xml += "</%s>" % k
+        .. versionadded:: 0.0.3
+        """
+        xml = ''
+        chunk = '<link rel="%s" href="%s" title="%s" />'
+        links = data.pop(config.LINKS, {})
+        ordered_links = OrderedDict(sorted(links.items()))
+        for rel, link in ordered_links.items():
+            if isinstance(link, list):
+                xml += ''.join([chunk % (rel, utils.escape(d['href']),
+                                         utils.escape(d['title']))
+                                for d in link])
             else:
-                xml += "<%s>%s</%s>" % (k, utils.escape(value), k)
-    return xml
+                xml += ''.join(chunk % (rel, utils.escape(link['href']),
+                                        link['title']))
+        return xml
+
+    @classmethod
+    def xml_add_items(cls, data):
+        """ When this function is called the datastream can only contain
+         a `_items` list, or a dictionary. If a list, each item is a resource
+        which rendered as XML. If a dictionary, it will be rendered as XML.
+
+        :param data: the data stream to be rendered as xml.
+
+        .. versionadded:: 0.0.3
+        """
+        try:
+            xml = ''.join([cls.xml_item(item) for item in data[config.ITEMS]])
+        except:
+            xml = cls.xml_dict(data)
+        return xml
+
+    @classmethod
+    def xml_item(cls, item):
+        """ Represents a single resource (member of a collection) as XML.
+
+        :param data: the data stream to be rendered as xml.
+
+        .. versionadded:: 0.0.3
+        """
+        xml = cls.xml_root_open(item)
+        xml += cls.xml_add_links(item)
+        xml += cls.xml_dict(item)
+        xml += cls.xml_root_close()
+        return xml
+
+    @classmethod
+    def xml_root_close(cls):
+        """ Returns the closing tag of the XML root node.
+
+        .. versionadded:: 0.0.3
+        """
+        return '</resource>'
+
+    @classmethod
+    def xml_dict(cls, data):
+        """ Renders a dict as XML.
+
+        :param data: the data stream to be rendered as xml.
+
+        .. versionchanged:: 0.5
+           Always return ordered items (#441).
+
+        .. versionchanged:: 0.2
+           Leaf values are now properly escaped.
+
+        .. versionadded:: 0.0.3
+        """
+        xml = ''
+        ordered_items = OrderedDict(sorted(data.items()))
+        for k, v in ordered_items.items():
+            if isinstance(v, datetime.datetime):
+                v = date_to_str(v)
+            elif isinstance(v, (datetime.time, datetime.date)):
+                v = v.isoformat()
+            if not isinstance(v, list):
+                v = [v]
+            for value in v:
+                if isinstance(value, dict):
+                    links = cls.xml_add_links(value)
+                    xml += "<%s>" % k
+                    xml += cls.xml_dict(value)
+                    xml += links
+                    xml += "</%s>" % k
+                else:
+                    xml += "<%s>%s</%s>" % (k, utils.escape(value), k)
+        return xml

--- a/eve/tests/renders.py
+++ b/eve/tests/renders.py
@@ -64,8 +64,7 @@ class TestRenders(TestBase):
         self.assertEqual(r.content_type, 'application/json')
 
     def test_json_xml_disabled(self):
-        self.app.config['JSON'] = False
-        self.app.config['XML'] = False
+        self.app.config['RENDERERS'] = tuple()
         r = self.test_client.get(self.known_resource_url,
                                  headers=[('Accept', 'application/json')])
         self.assert500(r.status_code)
@@ -76,7 +75,7 @@ class TestRenders(TestBase):
         self.assert500(r.status_code)
 
     def test_json_disabled(self):
-        self.app.config['JSON'] = False
+        self.app.config['RENDERERS'] = ('eve.render.XMLRenderer',)
         r = self.test_client.get(self.known_resource_url,
                                  headers=[('Accept', 'application/json')])
         self.assertTrue('application/xml' in r.content_type)
@@ -87,7 +86,7 @@ class TestRenders(TestBase):
         self.assertTrue('application/xml' in r.content_type)
 
     def test_xml_disabled(self):
-        self.app.config['XML'] = False
+        self.app.config['RENDERERS'] = ('eve.render.JSONRenderer',)
         r = self.test_client.get(self.known_resource_url,
                                  headers=[('Accept', 'application/xml')])
         self.assertEqual(r.content_type, 'application/json')

--- a/eve/tests/utils.py
+++ b/eve/tests/utils.py
@@ -7,7 +7,7 @@ from datetime import datetime, timedelta
 from eve.tests import TestBase
 from eve.utils import parse_request, str_to_date, config, weak_date, \
     date_to_str, querydef, document_etag, extract_key_values, \
-    debug_error_message, validate_filters
+    debug_error_message, validate_filters, import_from_string
 
 
 class TestUtils(TestBase):
@@ -260,6 +260,10 @@ class TestUtils(TestBase):
             self.assertTrue(validate_filters(
                 {'$or': [{'key': 'val1'}, {'key': 'val2'}]},
                 self.known_resource) is None)
+
+    def test_import_from_string(self):
+        dt = import_from_string('datetime.datetime')
+        self.assertEqual(dt, datetime)
 
 
 class DummyEvent(object):

--- a/eve/utils.py
+++ b/eve/utils.py
@@ -11,6 +11,8 @@
 """
 
 import sys
+from importlib import import_module
+
 import eve
 import hashlib
 import werkzeug.exceptions
@@ -448,3 +450,15 @@ def auto_fields(resource):
 
 # Base string type that is compatible with both Python 2.x and 3.x.
 str_type = str if sys.version_info[0] == 3 else basestring
+
+
+def import_from_string(module_name):
+    """ Imports module using string
+
+    """
+    try:
+        modules = module_name.split('.')
+        module_path, attr = '.'.join(modules[:-1]), modules[-1]
+        return getattr(import_module(module_path), attr)
+    except (ImportError, AttributeError):
+        raise ImportError('Cannot import {}'.format(module_name))

--- a/py26-requirements.txt
+++ b/py26-requirements.txt
@@ -1,2 +1,3 @@
 -r requirements.txt
 backport_collections==0.1
+importlib==1.0.4

--- a/setup.py
+++ b/setup.py
@@ -19,9 +19,11 @@ install_requires = [
 
 try:
     from collections import Counter, OrderedDict  # noqa
+    import importlib
 except ImportError:
     # Python 2.6
     install_requires.append('backport_collections')
+    install_requires.append('importlib==1.0.4')
 
 
 setup(

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py36
+envlist=py26,py27,py33,py34,py35,py36,pypy
 
 [testenv]
 commands=python setup.py test {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py26,py27,py33,py34,py35,py36,pypy
+envlist=py36
 
 [testenv]
 commands=python setup.py test {posargs}


### PR DESCRIPTION
Hello,

Recently I was working on API which handles a lot of float values in responses. One of the issues I encountered was having NaN values unquoted in the JSON response. `simplejson` allows changing those NaNs to null values in the fly using the `ignore_nan=True` argument. Eve has already this nice feature that allows using custom `app.data.json_encoder_class` but even if the custom JSON encoder class has ignore_nan set to `True`, that is still ignored and falls back to the default value which is `False`. 

My idea is to have new key in the settings called `RENDERERS`. This is a tuple containing module path to Renderer classes. This way developer is allowed to simply extend the default Eve's functionality to new renderers. For example - using [ujson](https://pypi.python.org/pypi/ujson), [pyYaml](http://pyyaml.org/wiki/PyYAML).

This change is rather big, so I would love to get your feedback on this. If you feel like it's a good idea, I will continue working on it, updating docs and extending docstrings.

Best,
Marcin
