### PR TITLE
1123 sub document validate filters

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -89,6 +89,7 @@ Patches and Contributions
 - Kurt Bonne
 - Kurt Doherty
 - Luca Di Gaspero
+- Luca Moretto
 - Luis Fernando Gomes
 - Magdas Adrian
 - Mandar Vaze

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -114,6 +114,14 @@ uppercase.
                                     ``/v1/<endpoint>``). Defaults to ``''``.
 
 ``ALLOWED_FILTERS``                 List of fields on which filtering is allowed.
+                                    Entries in this list work in a hierarchical
+                                    way. This means that, for instance, filtering
+                                    on ``'dict.sub_dict.foo'`` is allowed if
+                                    ``ALLOWED_FILTERS`` contains any of
+                                    ``'dict.sub_dict.foo``, ``'dict.sub_dict'``
+                                    or ``'dict'``. Instead filtering on
+                                    ``'dict'`` is allowed if ``ALLOWED_FILTERS``
+                                    contains ``'dict'``.
                                     Can be set to ``[]`` (no filters allowed)
                                     or ``['*']`` (filters allowed on every
                                     field). Unless your API is comprised of
@@ -798,6 +806,14 @@ always lowercase.
                                 :ref:`subresources`.
 
 ``allowed_filters``             List of fields on which filtering is allowed.
+                                Entries in this list work in a hierarchical
+                                way. This means that, for instance, filtering
+                                on ``'dict.sub_dict.foo'`` is allowed if
+                                ``allowed_filters`` contains any of
+                                ``'dict.sub_dict.foo``, ``'dict.sub_dict'``
+                                or ``'dict'``. Instead filtering on
+                                ``'dict'`` is allowed if ``allowed_filters``
+                                contains ``'dict'``.
                                 Can be set to ``[]`` (no filters allowed), or
                                 ``['*']`` (fields allowed on every field).
                                 Defaults to ``['*']``.

--- a/eve/tests/methods/get.py
+++ b/eve/tests/methods/get.py
@@ -1099,6 +1099,36 @@ class TestGet(TestBase):
         response, status = self.get(self.known_resource, where)
         self.assert200(status)
 
+        # test for nested resource field validating correctly
+        # (location is dict)
+        where = '?where={"location.address": "str 1"}'
+        response, status = self.get(self.known_resource, where)
+        self.assert200(status)
+
+        # test for nested resource field validating correctly
+        # (rows is list of dicts)
+        where = '?where={"rows.price": 10}'
+        response, status = self.get(self.known_resource, where)
+        self.assert200(status)
+
+        # test for nested resource field validating correctly
+        # (dict_list_fixed_len is a fixed-size list of dicts)
+        where = '?where={"dict_list_fixed_len.key2": 1}'
+        response, status = self.get(self.known_resource, where)
+        self.assert200(status)
+
+        # test for nested resource field not validating correctly
+        # (bad_base_key doesn't exist in the base resource schema)
+        where = '?where={"bad_base_key.sub": 1}'
+        response, status = self.get(self.known_resource, where)
+        self.assert400(status)
+
+        # test for nested resource field not validating correctly
+        # (bad_sub_key doesn't exist in the dict_list_fixed_len schema)
+        where = '?where={"dict_list_fixed_len.bad_sub_key": 1}'
+        response, status = self.get(self.known_resource, where)
+        self.assert400(status)
+
     def test_get_lookup_field_as_string(self):
         # Test that a resource where 'item_lookup_field' is set to a field
         # of string type and which value is castable to a ObjectId is still

--- a/eve/tests/methods/get.py
+++ b/eve/tests/methods/get.py
@@ -535,6 +535,28 @@ class TestGet(TestBase):
                                            '?where=%s' % where))
         self.assert200(r.status_code)
 
+        # `allowed_filters` contains "rows" --> filter key "rows.price" must be allowed
+        self.app.config['DOMAIN'][self.known_resource]['allowed_filters'] = \
+            ['rows']
+        where = '{"rows.price": 10}'
+        r = self.test_client.get('%s%s' % (self.known_resource_url,
+                                           '?where=%s' % where))
+        self.assert200(r.status_code)
+
+        # `allowed_filters` contains "rows.price" --> filter key "rows.price" must be allowed
+        self.app.config['DOMAIN'][self.known_resource]['allowed_filters'] = \
+            ['rows.price']
+        r = self.test_client.get('%s%s' % (self.known_resource_url,
+                                           '?where=%s' % where))
+        self.assert200(r.status_code)
+
+        # `allowed_filters` contains "rows.price" --> filter key "rows" must NOT be allowed
+        where = '{"rows": {"sku": "value", "price": 10}}'
+        r = self.test_client.get('%s%s' % (self.known_resource_url,
+                                           '?where=%s' % where))
+        self.assert400(r.status_code)
+        self.assertTrue(b"'rows' not allowed" in r.get_data())
+
     def test_get_with_post_override(self):
         # POST request with GET override turns into a GET
         headers = [('X-HTTP-Method-Override', 'GET')]

--- a/eve/tests/methods/get.py
+++ b/eve/tests/methods/get.py
@@ -535,7 +535,8 @@ class TestGet(TestBase):
                                            '?where=%s' % where))
         self.assert200(r.status_code)
 
-        # `allowed_filters` contains "rows" --> filter key "rows.price" must be allowed
+        # `allowed_filters` contains "rows" --> filter key "rows.price"
+        # must be allowed
         self.app.config['DOMAIN'][self.known_resource]['allowed_filters'] = \
             ['rows']
         where = '{"rows.price": 10}'
@@ -543,14 +544,16 @@ class TestGet(TestBase):
                                            '?where=%s' % where))
         self.assert200(r.status_code)
 
-        # `allowed_filters` contains "rows.price" --> filter key "rows.price" must be allowed
+        # `allowed_filters` contains "rows.price" --> filter key "rows.price"
+        # must be allowed
         self.app.config['DOMAIN'][self.known_resource]['allowed_filters'] = \
             ['rows.price']
         r = self.test_client.get('%s%s' % (self.known_resource_url,
                                            '?where=%s' % where))
         self.assert200(r.status_code)
 
-        # `allowed_filters` contains "rows.price" --> filter key "rows" must NOT be allowed
+        # `allowed_filters` contains "rows.price" --> filter key "rows"
+        # must NOT be allowed
         where = '{"rows": {"sku": "value", "price": 10}}'
         r = self.test_client.get('%s%s' % (self.known_resource_url,
                                            '?where=%s' % where))

--- a/eve/tests/test_settings.py
+++ b/eve/tests/test_settings.py
@@ -100,6 +100,19 @@ contacts = {
             'type': 'list',
             'items': [{'type': 'objectid'}]
         },
+        'dict_list_fixed_len': {
+            'type': 'list',
+            'items': [
+                {
+                    'type': 'dict',
+                    'schema': {'key1': {'type': 'string'}}
+                },
+                {
+                    'type': 'dict',
+                    'schema': {'key2': {'type': 'integer'}}
+                }
+            ]
+        },
         'dependency_field1': {
             'type': 'string',
             'default': 'default'

--- a/eve/utils.py
+++ b/eve/utils.py
@@ -388,15 +388,20 @@ def validate_filters(where, resource):
         for key, value in filter.items():
             if '*' not in allowed:
                 def recursive_check_allowed(filter_key, allowed_filters):
-                    # Filter key can be a plain key (e.g. "foo") or a dotted key (e.g. "dict.sub_dict.bar").
-                    # Starting from a dotted key, this function recursively checks `allowed_filters` for the key
-                    # itself and for all its parent keys.
-                    # This means that, for instance, "dict.sub_dict.bar" is an allowed filter key if `allowed_filters`
-                    # contains any of "dict.sub_dict.bar", "dict.sub_dict" or "dict".
-                    # Instead "dict" is an allowed filter key IFF `allowed_filters` contains "dict".
+                    # Filter key can be a plain key (e.g. "foo") or a dotted
+                    # key (e.g. "dict.sub_dict.bar").
+                    # Starting from a dotted key, this function recursively
+                    # checks `allowed_filters` for the key itself and for all
+                    # its parent keys.
+                    # This means that, for instance, "dict.sub_dict.bar" is
+                    # an allowed filter key if `allowed_filters` contains any
+                    # of "dict.sub_dict.bar", "dict.sub_dict" or "dict".
+                    # Instead "dict" is an allowed filter key IFF
+                    # `allowed_filters` contains "dict".
                     if filter_key not in allowed_filters:
                         base_composed_key, _, _ = filter_key.rpartition('.')
-                        return base_composed_key and recursive_check_allowed(base_composed_key, allowed_filters)
+                        return base_composed_key and recursive_check_allowed(
+                            base_composed_key, allowed_filters)
 
                     return True
 
@@ -424,11 +429,13 @@ def validate_filters(where, resource):
 
                         if base_schema.get('type') == 'list':
                             if 'schema' in base_schema:
-                                # Try to get dict sub-schema for arbitrary sized list
+                                # Try to get dict sub-schema for arbitrary
+                                # sized list
                                 sub = dict_sub_schema(base_schema['schema'])
                                 return [sub] if sub is not None else []
                             elif 'items' in base_schema:
-                                # Try to get dict sub-schema(s) for fixed-size list
+                                # Try to get dict sub-schema(s) for
+                                # fixed-size list
                                 items = base_schema['items']
                                 sub_schemas = []
                                 for item in items:
@@ -445,9 +452,13 @@ def validate_filters(where, resource):
                         if key not in schema:
                             base_key, _, sub_keys = key.partition('.')
                             if sub_keys and base_key in schema:
-                                # key is the composition of base field and sub-fields
-                                for sub_schema in get_sub_schemas(schema[base_key]):
-                                    if recursive_validate_filter(sub_keys, value, sub_schema):
+                                # key is the composition of base field and
+                                # sub-fields
+                                sub_schemas = get_sub_schemas(schema[base_key])
+                                for sub_schema in sub_schemas:
+                                    if recursive_validate_filter(sub_keys,
+                                                                 value,
+                                                                 sub_schema):
                                         return True
 
                             return False

--- a/eve/utils.py
+++ b/eve/utils.py
@@ -388,16 +388,6 @@ def validate_filters(where, resource):
         for key, value in filter.items():
             if '*' not in allowed:
                 def recursive_check_allowed(filter_key, allowed_filters):
-                    # Filter key can be a plain key (e.g. "foo") or a dotted
-                    # key (e.g. "dict.sub_dict.bar").
-                    # Starting from a dotted key, this function recursively
-                    # checks `allowed_filters` for the key itself and for all
-                    # its parent keys.
-                    # This means that, for instance, "dict.sub_dict.bar" is
-                    # an allowed filter key if `allowed_filters` contains any
-                    # of "dict.sub_dict.bar", "dict.sub_dict" or "dict".
-                    # Instead "dict" is an allowed filter key IFF
-                    # `allowed_filters` contains "dict".
                     if filter_key not in allowed_filters:
                         base_composed_key, _, _ = filter_key.rpartition('.')
                         return base_composed_key and recursive_check_allowed(


### PR DESCRIPTION
This PR fixes issue #1123 

Also, commit bae6757 fixes the behavior of `ALLOWED_FILTERS` (and the related resource-specific `allowed_fillters`) settings in the same scenario as the one defined in #1123, i.e. filtering on a sub-document field.