### PR TITLE
$caseSensitive and $diacriticSensitive

### DIFF
--- a/eve/io/mongo/mongo.py
+++ b/eve/io/mongo/mongo.py
@@ -95,8 +95,8 @@ class Mongo(DataLayer):
         ['$gt', '$gte', '$in', '$lt', '$lte', '$ne', '$nin'] +
         ['$or', '$and', '$not', '$nor'] +
         ['$mod', '$regex', '$text', '$where'] +
-        ['$options', '$search', '$language'] +
-        ['$exists', '$type'] +
+        ['$options', '$search', '$language', '$caseSensitive'] +
+        ['$diacriticSensitive', '$exists', '$type'] +
         ['$geoWithin', '$geoIntersects', '$near', '$nearSphere'] +
         ['$all', '$elemMatch', '$size']
     )


### PR DESCRIPTION
Added support for Mongo 3.2+ $caseSensitive and $diacriticSensitive params in $text operator.

Mongo documentation: https://docs.mongodb.com/v3.2/reference/operator/query/text/#op._S_text