### PR TITLE
Fix #1036 : allow client projection with server-side exclusion.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -166,3 +166,5 @@ Patches and Contributions
 - kreynen
 - mmizotin
 - xgdgsc
+- Hugo Larcher
+- Huan Di

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -481,11 +481,11 @@ uppercase.
 ``JSON_SORT_KEYS``                  ``True`` to enable JSON key sorting, ``False``
                                     otherwise. Defaults to ``False``.
 
-``JSON_REQUEST_CONTENT_TYPES``      Supported JSON content types. Useful when 
+``JSON_REQUEST_CONTENT_TYPES``      Supported JSON content types. Useful when
                                     you need support for vendor-specific json
                                     types. Please note: responses will still
                                     carry the standard ``application/json``
-                                    type. Defaults to ``['application/json']``. 
+                                    type. Defaults to ``['application/json']``.
 
 ``VALIDATION_ERROR_STATUS``         The HTTP status code to use for validation errors.
                                     Defaults to ``422``.
@@ -1321,13 +1321,13 @@ defining the field validation rules. Allowed validation rules are:
                                 set in the list. See `*of-rules <http://docs.python-cerberus.org/en/latest/validation-rules.html#of-rules>`_ in Cerberus docs.
 
 ``allof``                       Same as ``anyof``, except that all rule
-                                collections in the list must validate. 
+                                collections in the list must validate.
 
 ``noneof``                      Same as ``anyof``, except that it requires no
                                 rule collections in the list to validate.
 
 ``oneof``                       Same as ``anyof``, except that only one rule
-                                collections in the list can validate. 
+                                collections in the list can validate.
 
 ``coerce``                      Type coercion allows you to apply a callable to
                                 a value before any other validators run. The
@@ -1477,6 +1477,14 @@ By default API responses to GET requests will include all fields defined by the
 corresponding resource schema_. The ``projection`` setting of the `datasource`
 resource keyword allows you to redefine the fieldset.
 
+When you want to hide some *secret fields* from client, you should use
+inclusive projection setting and include all fields should be exposed. While,
+when you want to limit default responsesto certain fields but still allow them
+to be accessible through client-side projections, you should use exclusive
+projection setting and exclude fields should be omitted.
+
+The following is an example for inclusive projection setting:
+
 ::
 
     people = {
@@ -1486,9 +1494,18 @@ resource keyword allows you to redefine the fieldset.
         }
 
 The above setting will expose only the `username` field to GET requests, no
-matter the schema_ defined for the resource.
+matter the schema_ defined for the resource. And other fields **will not** be
+exposed even by client-side projection. The following API call will not return
+`lastname` or `born`.
 
-Likewise, you can exclude fields from API responses:
+.. code-block:: console
+
+    $ curl -i http://eve-demo.herokuapp.com/people?projection={"lastname": 1, "born": 1}
+    HTTP/1.1 200 OK
+
+You can also exclude fields from API responses. But this time, the excluded
+fields **will be** exposed to client-side projection. The following is an
+example for exclusive projection setting:
 
 ::
 
@@ -1498,7 +1515,19 @@ Likewise, you can exclude fields from API responses:
             }
         }
 
-The above will include all document fields but `username`.
+The above will include all document fields but `username`. However, the
+following API call will return `username` this time. Thus, you can exploit this
+behaviour to serve media fields or other expensive fields.
+
+In most cases, none or inclusive projection setting is more preferred. With
+inclusive projection, secret fields are taken care from server side, and default
+fields returned can be defined by short-cut functions from client-side.
+
+.. code-block:: console
+
+    $ curl -i http://eve-demo.herokuapp.com/people?projection={"username": 1}
+    HTTP/1.1 200 OK
+
 
 Please note that POST and PATCH methods will still allow the whole schema to be
 manipulated. This feature can come in handy when, for example, you want to

--- a/eve/flaskapp.py
+++ b/eve/flaskapp.py
@@ -666,7 +666,6 @@ class Eve(Flask, Events):
         ds.setdefault('default_sort', None)
 
         self._set_resource_projection(ds, schema, settings)
-
         aggregation = ds.setdefault('aggregation', None)
         if aggregation:
             aggregation.setdefault('options', {})
@@ -688,18 +687,27 @@ class Eve(Flask, Events):
 
         projection = ds.get('projection', {})
 
-        # check if any exclusion projection is defined
-        exclusion = any(((k, v) for k, v in projection.items() if v == 0)) \
-            if projection else None
-
-        # If no exclusion projection is defined, enhance the projection
-        # with automatic fields. Using both inclusion and exclusion will
-        # be rejected by Mongo
-        if not exclusion and len(schema) and \
-           settings['allow_unknown'] is False:
+        # If exclusion projections are defined, they are use for
+        # concealing fields (rather than actual mongo exlusions).
+        # If inclusion projections are defined, exclusion projections are
+        # just ignored.
+        exclusion_projection = {k: v for k, v in projection.items()
+                                if v == 0}
+        inclusion_projection = {k: v for k, v in projection.items()
+                                if v == 1}
+        if exclusion_projection or inclusion_projection:
+            projection = inclusion_projection
+            ds['projection'] = projection
+        # Enhance the projection with automatic fields.
+        if len(schema) and settings['allow_unknown'] is False:
+            # use all fields not excluded
             if not projection:
-                projection.update(dict((field, 1) for (field) in schema))
-
+                projection.update(
+                    dict((field, 1) for (field) in schema
+                         if field not in exclusion_projection))
+            # add back exclusion projection, and deal with them together with
+            # client projection later in 'io/base.py'
+            projection.update(exclusion_projection)
             # enable retrieval of actual schema fields only. Eventual db
             # fields not included in the schema won't be returned.
             # despite projection, automatic fields are always included.
@@ -717,7 +725,7 @@ class Eve(Flask, Events):
             projection = None
         ds.setdefault('projection', projection)
 
-        if settings['soft_delete'] is True and not exclusion and \
+        if settings['soft_delete'] is True and \
                 ds['projection'] is not None:
             ds['projection'][self.config['DELETED']] = 1
 

--- a/eve/io/base.py
+++ b/eve/io/base.py
@@ -439,6 +439,10 @@ class DataLayer(object):
                 # there's no standard projection so we assume we are in a
                 # allow_unknown = True
                 fields = client_projection
+        else:
+            # drop exclusion projection
+            fields = dict([(field, 1) for field, value in fields.items() if
+                        value])
 
         # If the current HTTP method is in `public_methods` or
         # `public_item_methods`, skip the `auth_field` check

--- a/eve/tests/__init__.py
+++ b/eve/tests/__init__.py
@@ -381,6 +381,17 @@ class TestBase(TestMinimal):
                                        self.domain[
                                            self.different_resource]['url'])
 
+        self.different_resource_exclude = 'contacts_hide_born'
+        self.different_resource_exclude_url = ('/%s' %
+                                       self.domain[
+                                           self.different_resource_exclude]['url'])
+
+        self.resource_exclude_media = 'contacts_hide_media'
+        self.resource_exclude_media_url = ('/%s' %
+                                       self.domain[
+                                           self.resource_exclude_media]['url'])
+
+
         response, _ = self.get('contacts', '?max_results=2')
         contact = self.response_item(response)
         self.item = contact

--- a/eve/tests/test_settings.py
+++ b/eve/tests/test_settings.py
@@ -169,6 +169,16 @@ users['resource_methods'] = ['DELETE', 'POST', 'GET']
 users['item_title'] = 'user'
 users['additional_lookup']['field'] = 'username'
 
+contacts_hide_born = copy.deepcopy(contacts)
+contacts_hide_born['url'] = 'contacts/hide_born'
+contacts_hide_born['datasource']['source'] = 'contacts'
+contacts_hide_born['datasource']['projection'] = {'born': 0}
+
+contacts_hide_media = copy.deepcopy(contacts)
+contacts_hide_media['url'] = 'contacts/hide_media'
+contacts_hide_media['datasource']['source'] = 'contacts'
+contacts_hide_media['datasource']['projection'] = {'media': 0, 'born': 0}
+
 invoices = {
     'schema': {
         'inv_number': {'type': 'string'},
@@ -326,6 +336,8 @@ DOMAIN = {
     'contacts': contacts,
     'users': users,
     'users_overseas': users_overseas,
+    'contacts_hide_born': contacts_hide_born,
+    'contacts_hide_media': contacts_hide_media,
     'invoices': invoices,
     'versioned_invoices': versioned_invoices,
     'required_invoices': required_invoices,


### PR DESCRIPTION
Changes:

- Add all fields not excluded to static projection
- Add tests and docs to these backward compatible behaviours