### PR TITLE
Allow client projection with static exclusive projection

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -166,3 +166,5 @@ Patches and Contributions
 - kreynen
 - mmizotin
 - xgdgsc
+- Hugo Larcher
+- Huan Di

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -481,11 +481,11 @@ uppercase.
 ``JSON_SORT_KEYS``                  ``True`` to enable JSON key sorting, ``False``
                                     otherwise. Defaults to ``False``.
 
-``JSON_REQUEST_CONTENT_TYPES``      Supported JSON content types. Useful when 
+``JSON_REQUEST_CONTENT_TYPES``      Supported JSON content types. Useful when
                                     you need support for vendor-specific json
                                     types. Please note: responses will still
                                     carry the standard ``application/json``
-                                    type. Defaults to ``['application/json']``. 
+                                    type. Defaults to ``['application/json']``.
 
 ``VALIDATION_ERROR_STATUS``         The HTTP status code to use for validation errors.
                                     Defaults to ``422``.
@@ -1321,13 +1321,13 @@ defining the field validation rules. Allowed validation rules are:
                                 set in the list. See `*of-rules <http://docs.python-cerberus.org/en/latest/validation-rules.html#of-rules>`_ in Cerberus docs.
 
 ``allof``                       Same as ``anyof``, except that all rule
-                                collections in the list must validate. 
+                                collections in the list must validate.
 
 ``noneof``                      Same as ``anyof``, except that it requires no
                                 rule collections in the list to validate.
 
 ``oneof``                       Same as ``anyof``, except that only one rule
-                                collections in the list can validate. 
+                                collections in the list can validate.
 
 ``coerce``                      Type coercion allows you to apply a callable to
                                 a value before any other validators run. The
@@ -1477,6 +1477,14 @@ By default API responses to GET requests will include all fields defined by the
 corresponding resource schema_. The ``projection`` setting of the `datasource`
 resource keyword allows you to redefine the fieldset.
 
+When you want to hide some *secret fields* from client, you should use
+inclusive projection setting and include all fields should be exposed. While,
+when you want to limit default responsesto certain fields but still allow them
+to be accessible through client-side projections, you should use exclusive
+projection setting and exclude fields should be omitted.
+
+The following is an example for inclusive projection setting:
+
 ::
 
     people = {
@@ -1486,9 +1494,18 @@ resource keyword allows you to redefine the fieldset.
         }
 
 The above setting will expose only the `username` field to GET requests, no
-matter the schema_ defined for the resource.
+matter the schema_ defined for the resource. And other fields **will not** be
+exposed even by client-side projection. The following API call will not return
+`lastname` or `born`.
 
-Likewise, you can exclude fields from API responses:
+.. code-block:: console
+
+    $ curl -i http://eve-demo.herokuapp.com/people?projection={"lastname": 1, "born": 1}
+    HTTP/1.1 200 OK
+
+You can also exclude fields from API responses. But this time, the excluded
+fields **will be** exposed to client-side projection. The following is an
+example for exclusive projection setting:
 
 ::
 
@@ -1498,7 +1515,19 @@ Likewise, you can exclude fields from API responses:
             }
         }
 
-The above will include all document fields but `username`.
+The above will include all document fields but `username`. However, the
+following API call will return `username` this time. Thus, you can exploit this
+behaviour to serve media fields or other expensive fields.
+
+In most cases, none or inclusive projection setting is more preferred. With
+inclusive projection, secret fields are taken care from server side, and default
+fields returned can be defined by short-cut functions from client-side.
+
+.. code-block:: console
+
+    $ curl -i http://eve-demo.herokuapp.com/people?projection={"username": 1}
+    HTTP/1.1 200 OK
+
 
 Please note that POST and PATCH methods will still allow the whole schema to be
 manipulated. This feature can come in handy when, for example, you want to

--- a/eve/io/base.py
+++ b/eve/io/base.py
@@ -423,7 +423,7 @@ class DataLayer(object):
                 # projection for the resource (avoid sniffing of private
                 # fields)
                 keep_fields = auto_fields(resource)
-                if 0 not in client_projection.values():
+                if 1 in client_projection.values():
                     # inclusive projection - all values are 0 unless spec. or
                     # auto
                     fields = dict([(field, field in keep_fields) for field in
@@ -432,18 +432,15 @@ class DataLayer(object):
                     field_base = field.split('.')[0]
                     if field_base not in keep_fields and field_base in fields:
                         fields[field] = value
-                fields = dict([(field, 1) for field, value in fields.items() if
-                               value])
             else:
                 # there's no standard projection so we assume we are in a
                 # allow_unknown = True
                 fields = client_projection
-        elif fields is not None:
-            # drop exclusion projection
-            fields = dict([(field, 1) for field, value in fields.items() if
-                           value])
-        # if fields == {}:
-        #     fields = None
+        # always drop exclusion projection, thus avoid mixed projection not
+        # supported by db driver
+        fields = dict([(field, 1) for field, value in fields.items() if
+                       value])
+
         # If the current HTTP method is in `public_methods` or
         # `public_item_methods`, skip the `auth_field` check
 

--- a/eve/io/base.py
+++ b/eve/io/base.py
@@ -392,7 +392,6 @@ class DataLayer(object):
         """
 
         datasource, filter_, projection_, sort_ = self.datasource(resource)
-
         if client_sort:
             sort = client_sort
         else:
@@ -439,7 +438,12 @@ class DataLayer(object):
                 # there's no standard projection so we assume we are in a
                 # allow_unknown = True
                 fields = client_projection
-
+        elif fields is not None:
+            # drop exclusion projection
+            fields = dict([(field, 1) for field, value in fields.items() if
+                           value])
+        # if fields == {}:
+        #     fields = None
         # If the current HTTP method is in `public_methods` or
         # `public_item_methods`, skip the `auth_field` check
 

--- a/eve/tests/__init__.py
+++ b/eve/tests/__init__.py
@@ -381,6 +381,14 @@ class TestBase(TestMinimal):
                                        self.domain[
                                            self.different_resource]['url'])
 
+        self.different_resource_exclude = 'contacts_hide_born'
+        self.different_resource_exclude_url = (
+            '/%s' % self.domain[self.different_resource_exclude]['url'])
+
+        self.resource_exclude_media = 'contacts_hide_media'
+        self.resource_exclude_media_url = (
+            '/%s' % self.domain[self.resource_exclude_media]['url'])
+
         response, _ = self.get('contacts', '?max_results=2')
         contact = self.response_item(response)
         self.item = contact

--- a/eve/tests/methods/post.py
+++ b/eve/tests/methods/post.py
@@ -416,7 +416,7 @@ class TestPost(TestBase):
         # don't have to re-initialize the whole app.)
         settings = self.app.config['DOMAIN'][self.known_resource]
         settings['allow_unknown'] = True
-        settings['datasource']['projection'] = None
+        settings['datasource']['projection'] = {}
 
         r, status = self.post(self.known_resource_url, data=data)
         self.assert201(status)

--- a/eve/tests/test_settings.py
+++ b/eve/tests/test_settings.py
@@ -169,6 +169,16 @@ users['resource_methods'] = ['DELETE', 'POST', 'GET']
 users['item_title'] = 'user'
 users['additional_lookup']['field'] = 'username'
 
+contacts_hide_born = copy.deepcopy(contacts)
+contacts_hide_born['url'] = 'contacts/hide_born'
+contacts_hide_born['datasource']['source'] = 'contacts'
+contacts_hide_born['datasource']['projection'] = {'born': 0}
+
+contacts_hide_media = copy.deepcopy(contacts)
+contacts_hide_media['url'] = 'contacts/hide_media'
+contacts_hide_media['datasource']['source'] = 'contacts'
+contacts_hide_media['datasource']['projection'] = {'media': 0, 'born': 0}
+
 invoices = {
     'schema': {
         'inv_number': {'type': 'string'},
@@ -326,6 +336,8 @@ DOMAIN = {
     'contacts': contacts,
     'users': users,
     'users_overseas': users_overseas,
+    'contacts_hide_born': contacts_hide_born,
+    'contacts_hide_media': contacts_hide_media,
     'invoices': invoices,
     'versioned_invoices': versioned_invoices,
     'required_invoices': required_invoices,


### PR DESCRIPTION
Fix #1036 : allow client projection with static exclusion

Changes:

- Enable client projection with static exclusive projection
- Enhance tests and docs accordingly

Projection behaviors:

- Static projection setting will allow client projection
- Static inclusive projection will block sniffing
- Static exclusive projection will allow sniffing
- Quite weird but backwards compatible...

This PR try to patch-fix the issue but not to mess up with existing code. 
However, current code may require some refactoring.

- NoneType projections are quite annoying and hard to maintain. Should they 
always be dictionaries and converted to None later (for flask-pymongo)?