### PR TITLE
Fix PUT behavior with User-Restricted Resource Access

### DIFF
--- a/eve/io/base.py
+++ b/eve/io/base.py
@@ -474,13 +474,7 @@ class DataLayer(object):
                             self.app.data.get_value_from_query(
                                 query, auth_field) != request_auth_value:
                             desc = 'Incompatible User-Restricted Resource ' \
-                                   'request. Request was for "%s"="%s" but ' \
-                                   '`auth_field` requires "%s"="%s".' % (
-                                       auth_field,
-                                       self.app.data.get_value_from_query(
-                                           query, auth_field),
-                                       auth_field,
-                                       request_auth_value)
+                                   'request.'
                             abort(401, description=desc)
                         else:
                             query = self.app.data.combine_queries(

--- a/eve/io/base.py
+++ b/eve/io/base.py
@@ -151,7 +151,8 @@ class DataLayer(object):
         """
         raise NotImplementedError
 
-    def find_one(self, resource, req, **lookup):
+    def find_one(self, resource, req, check_auth_value=True,
+                 force_auth_field_projection=False, **lookup):
         """ Retrieves a single document/record. Consumed when a request hits an
         item endpoint (`/people/id/`).
 
@@ -164,6 +165,14 @@ class DataLayer(object):
                     etc). As we are going to only look for one document here,
                     the only req attribute that you want to process here is
                     ``req.projection``.
+        :param check_auth_value: a boolean flag indicating if the find
+                                 operation should consider user-restricted
+                                 resource access. Defaults to ``True``.
+        :param force_auth_field_projection: a boolean flag indicating if the
+                                            find operation should always
+                                            include the user-restricted
+                                            resource access field (if
+                                            configured). Defaults to ``False``.
 
         :param **lookup: the lookup fields. This will most likely be a record
                          id or, if alternate lookup is supported by the API,
@@ -343,7 +352,8 @@ class DataLayer(object):
         return source, filter_, projection, sort,
 
     def _datasource_ex(self, resource, query=None, client_projection=None,
-                       client_sort=None):
+                       client_sort=None, check_auth_value=True,
+                       force_auth_field_projection=False):
         """ Returns both db collection and exact query (base filter included)
         to which an API resource refers to.
 
@@ -446,35 +456,40 @@ class DataLayer(object):
 
         # Only inject the auth_field in the query when not creating new
         # documents.
-        if request and request.method not in ('POST', 'PUT'):
+        if request and request.method != 'POST' and (
+            check_auth_value or force_auth_field_projection
+        ):
             auth_field, request_auth_value = auth_field_and_value(resource)
-            if auth_field and request_auth_value:
-                if query:
-                    # If the auth_field *replaces* a field in the query,
-                    # and the values are /different/, deny the request
-                    # This prevents the auth_field condition from
-                    # overwriting the query (issue #77)
-                    auth_field_in_query = \
-                        self.app.data.query_contains_field(query, auth_field)
-                    if auth_field_in_query and \
+            if auth_field:
+                if request_auth_value and check_auth_value:
+                    if query:
+                        # If the auth_field *replaces* a field in the query,
+                        # and the values are /different/, deny the request
+                        # This prevents the auth_field condition from
+                        # overwriting the query (issue #77)
+                        auth_field_in_query = \
+                            self.app.data.query_contains_field(query,
+                                                               auth_field)
+                        if auth_field_in_query and \
                             self.app.data.get_value_from_query(
                                 query, auth_field) != request_auth_value:
-                        abort(401, description='Incompatible User-Restricted '
-                              'Resource request. '
-                              'Request was for "%s"="%s" but `auth_field` '
-                              'requires "%s"="%s".' % (
-                                  auth_field,
-                                  self.app.data.get_value_from_query(
-                                      query, auth_field),
-                                  auth_field,
-                                  request_auth_value)
-                              )
+                            desc = 'Incompatible User-Restricted Resource ' \
+                                   'request. Request was for "%s"="%s" but ' \
+                                   '`auth_field` requires "%s"="%s".' % (
+                                       auth_field,
+                                       self.app.data.get_value_from_query(
+                                           query, auth_field),
+                                       auth_field,
+                                       request_auth_value)
+                            abort(401, description=desc)
+                        else:
+                            query = self.app.data.combine_queries(
+                                query, {auth_field: request_auth_value}
+                            )
                     else:
-                        query = self.app.data.combine_queries(
-                            query, {auth_field: request_auth_value}
-                        )
-                else:
-                    query = {auth_field: request_auth_value}
+                        query = {auth_field: request_auth_value}
+                if force_auth_field_projection:
+                    fields[auth_field] = 1
         return datasource, query, fields, sort
 
     def _client_projection(self, req):

--- a/eve/io/mongo/mongo.py
+++ b/eve/io/mongo/mongo.py
@@ -277,7 +277,8 @@ class Mongo(DataLayer):
 
         return self.pymongo(resource).db[datasource].find(**args)
 
-    def find_one(self, resource, req, **lookup):
+    def find_one(self, resource, req, check_auth_value=True,
+                 force_auth_field_projection=False, **lookup):
         """ Retrieves a single document.
 
         :param resource: resource name.
@@ -312,7 +313,9 @@ class Mongo(DataLayer):
         datasource, filter_, projection, _ = self._datasource_ex(
             resource,
             lookup,
-            client_projection)
+            client_projection,
+            check_auth_value=check_auth_value,
+            force_auth_field_projection=force_auth_field_projection)
 
         if (config.DOMAIN[resource]['soft_delete']) and \
                 (not req or not req.show_deleted) and \

--- a/eve/methods/common.py
+++ b/eve/methods/common.py
@@ -34,7 +34,9 @@ except:
     from backport_collections import Counter
 
 
-def get_document(resource, concurrency_check, original=None, **lookup):
+def get_document(resource, concurrency_check, original=None,
+                 check_auth_value=True, force_auth_field_projection=False,
+                 **lookup):
     """ Retrieves and return a single document. Since this function is used by
     the editing methods (PUT, PATCH, DELETE), we make sure that the client
     request references the current representation of the document before
@@ -45,6 +47,14 @@ def get_document(resource, concurrency_check, original=None, **lookup):
     :param resource: the name of the resource to which the document belongs to.
     :param concurrency_check: boolean check for concurrency control
     :param original: in case the document was already retrieved before
+    :param check_auth_value: a boolean flag indicating if the find operation
+                             should consider user-restricted resource
+                             access. Defaults to ``True``.
+    :param force_auth_field_projection: a boolean flag indicating if the
+                                        find operation should always include
+                                        the user-restricted resource access
+                                        field (if configured). Defaults to
+                                        ``False``.
     :param **lookup: document lookup query
 
     .. versionchanged:: 0.6
@@ -70,7 +80,9 @@ def get_document(resource, concurrency_check, original=None, **lookup):
     if original:
         document = original
     else:
-        document = app.data.find_one(resource, req, **lookup)
+        document = app.data.find_one(resource, req, check_auth_value,
+                                     force_auth_field_projection,
+                                     **lookup)
 
     if document:
         e_if_m = config.ENFORCE_IF_MATCH

--- a/eve/tests/auth.py
+++ b/eve/tests/auth.py
@@ -643,8 +643,28 @@ class TestUserRestrictedAccess(TestBase):
                                  headers=headers,
                                  content_type='application/json'))
         self.assert200(status)
+        etag = '"%s"' % response['_etag']
 
         # document still accessible with same auth
+        data, status = self.parse_response(
+            self.test_client.get(url, headers=self.valid_auth))
+        self.assert200(status)
+        self.assertEqual(data['ref'], new_ref)
+
+        # put on same item with different auth fails
+        original_auth_val = self.resource['authentication'].request_auth_value
+        self.resource['authentication'].request_auth_value = 'alt'
+        alt_auth = ('Authorization', 'Basic YWx0OnNlY3JldA==')
+        alt_changes = {"ref": "1111111111111111111111111"}
+        headers = [('If-Match', etag), alt_auth]
+        response, status = self.parse_response(
+            self.test_client.put(url, data=json.dumps(alt_changes),
+                                 headers=headers,
+                                 content_type='application/json'))
+        self.assert403(status)
+
+        # document still accessible with original auth
+        self.resource['authentication'].request_auth_value = original_auth_val
         data, status = self.parse_response(
             self.test_client.get(url, headers=self.valid_auth))
         self.assert200(status)
@@ -680,8 +700,28 @@ class TestUserRestrictedAccess(TestBase):
                                        headers=headers,
                                        content_type='application/json'))
         self.assert200(status)
+        etag = '"%s"' % response['_etag']
 
         # document still accessible with same auth
+        data, status = self.parse_response(
+            self.app.test_client().get(url, headers=self.valid_auth))
+        self.assert200(status)
+        self.assertEqual(data['ref'], new_ref)
+
+        # put on same item with different auth fails
+        original_auth_val = resource_def['authentication'].request_auth_value
+        resource_def['authentication'].request_auth_value = 'alt'
+        alt_auth = ('Authorization', 'Basic YWx0OnNlY3JldA==')
+        alt_changes = {"ref": "1111111111111111111111111"}
+        headers = [('If-Match', etag), alt_auth]
+        response, status = self.parse_response(
+            self.app.test_client().put(url, data=json.dumps(alt_changes),
+                                       headers=headers,
+                                       content_type='application/json'))
+        self.assert403(status)
+
+        # document still accessible with original auth
+        resource_def['authentication'].request_auth_value = original_auth_val
         data, status = self.parse_response(
             self.app.test_client().get(url, headers=self.valid_auth))
         self.assert200(status)


### PR DESCRIPTION
This PR fixes the behavior of PUT requests when User-Restricted Resource Access is enabled.

More in particular it ensures that, under every circumstance, users are unable to overwrite items owned by other users.