### PR TITLE
Make merging of nested documents optional (enabled by default)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,6 +8,7 @@ Development Lead
 
 Patches and Contributions
 `````````````````````````
+- Alexander Dietmüller
 - Alexander Hendorf
 - Amedeo Bussi
 - Andreas Røssland
@@ -122,7 +123,6 @@ Patches and Contributions
 - Nick Park
 - Nicolas Bazire
 - Nicolas Carlier
-- NotSpecial
 - Olivier Carrère
 - Olivier Poitrey
 - Olof Johansson

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -754,6 +754,11 @@ uppercase.
                                     disable this feature, and a ``404`` will be
                                     returned instead. Defaults to ``True``.
 
+``MERGE_NESTED_DOCUMENTS``          If ``True``, updates to nested fields are
+                                    merged with the current data on ``PATCH``.
+                                    If ``False``, the updates overwrite the
+                                    current data. Defaults to ``True``.
+
 =================================== =========================================
 
 .. _domain:
@@ -1083,6 +1088,12 @@ always lowercase.
 ``soft_delete``                 When ``True`` this option enables the
                                 :ref:`soft_delete` feature for this resource.
                                 Locally overrides ``SOFT_DELETE``.
+
+``merge_nested_documents``      If ``True``, updates to nested fields are
+                                merged with the current data on ``PATCH``.
+                                If ``False``, the updates overwrite the
+                                current data. Locally overrides
+                                ``MERGE_NESTED_DOCUMENTS``.
 
 =============================== ===============================================
 

--- a/eve/default_settings.py
+++ b/eve/default_settings.py
@@ -204,6 +204,7 @@ ITEM_LOOKUP = True
 ITEM_LOOKUP_FIELD = ID_FIELD
 ITEM_URL = 'regex("[a-f0-9]{24}")'
 UPSERT_ON_PUT = True            # insert unexisting documents on PUT.
+MERGE_NESTED_DOCUMENTS = True
 
 # use a simple file response format by default
 EXTENDED_MEDIA_INFO = []

--- a/eve/flaskapp.py
+++ b/eve/flaskapp.py
@@ -646,6 +646,8 @@ class Eve(Flask, Events):
         settings.setdefault('hateoas',
                             self.config['HATEOAS'])
         settings.setdefault('authentication', self.auth if self.auth else None)
+        settings.setdefault('merge_nested_documents',
+                            self.config['MERGE_NESTED_DOCUMENTS'])
         # empty schemas are allowed for read-only access to resources
         schema = settings.setdefault('schema', {})
         self.set_schema_defaults(schema, settings['id_field'])

--- a/eve/methods/patch.py
+++ b/eve/methods/patch.py
@@ -193,8 +193,9 @@ def patch_internal(resource, payload=None, concurrency_check=False,
             getattr(app, "on_update")(resource, updates, original)
             getattr(app, "on_update_%s" % resource)(updates, original)
 
-            updates = resolve_nested_documents(updates, updated)
-            updated.update(updates)
+            if resource_def['merge_nested_documents']:
+                updates = resolve_nested_documents(updates, updated)
+                updated.update(updates)
 
             if config.IF_MATCH:
                 resolve_document_etag(updated, resource)


### PR DESCRIPTION
Rationale
---------

In the fix for #519, merging of nested documents on `PATCH` was introduced,
essentially a `original.update(updates)` is performed.
So far, the only way to avoid this is to use `PUT` (see #712), however,
this is not always desirable.

We have a use case where we only want to update a nested field of a
document, therefore the appropriate HTML verb is `PATCH` since we do not want
to replace the whole document.
In this nested field, we need to remove a key, which, due to the merging,
is currently impossible.

Changes
-------

- Introduce a new setting, `MERGE_NESTED_DOCUMENTS`, to control this behaviour
  globally or per-resource.
  Per default, this is set to `True`, so that nothing changes compares to the
  current version of Eve except when the configuration is changed explicitly.
- Add a test
- Add documentation