### PR TITLE
Fixing issue 1175

### DIFF
--- a/eve/flaskapp.py
+++ b/eve/flaskapp.py
@@ -294,7 +294,7 @@ class Eve(Flask, Events):
             msg = "{} setting is deprecated and will be removed" " in future release. Please use RENDERERS instead."
 
             if "JSON" in self.config or "XML" in self.config:
-                self.config["RENDERERS"] = default_settings.RENDERERS.copy()
+                self.config["RENDERERS"] = default_settings.RENDERERS[:]
 
             if "JSON" in self.config:
                 warnings.warn(msg.format("JSON"))


### PR DESCRIPTION
This PR fixes issue 1175. According to Python documentation ([here](https://docs.python.org/3/library/stdtypes.html#mutable-sequence-types)), the copy() function is only available for Python 3.3+. To support Python 2.7.X, a change is needed.
According to the documentation, list.copy() is equal to list[:].