### PR TITLE
Provide document validations to cerberus

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: all install-dev test test-all tox docs audit clean-pyc docs-upload
 
 install-dev:
-	pip install -q -e .[dev]
+	pip install -q -e .[dev] --process-dependency-links
 
 test: clean-pyc install-dev
 	pytest

--- a/eve/__init__.py
+++ b/eve/__init__.py
@@ -38,7 +38,7 @@
 
 """
 
-__version__ = "0.8.1.dev0"
+__version__ = "0.8.1.dev0.cri.1.0"
 
 # RFC 1123 (ex RFC 822)
 DATE_FORMAT = "%a, %d %b %Y %H:%M:%S GMT"

--- a/eve/__init__.py
+++ b/eve/__init__.py
@@ -38,7 +38,7 @@
 
 """
 
-__version__ = "0.8.1.dev0.cri.1.0"
+__version__ = "0.8.1.dev0+cri.1.0"
 
 # RFC 1123 (ex RFC 822)
 DATE_FORMAT = "%a, %d %b %Y %H:%M:%S GMT"

--- a/eve/validation.py
+++ b/eve/validation.py
@@ -25,6 +25,11 @@ class Validator(cerberus.Validator):
         if not config.VALIDATION_ERROR_AS_LIST:
             kwargs["error_handler"] = SingleErrorAsStringErrorHandler
 
+        resource = kwargs.get("resource", None)
+        if resource:
+            resource_def = config.DOMAIN[resource]
+            kwargs["document_validations"] = resource_def.get("document_validations")
+
         super(Validator, self).__init__(*args, **kwargs)
 
     def validate_update(self, document, document_id, persisted_document=None):

--- a/setup.py
+++ b/setup.py
@@ -12,14 +12,16 @@ with io.open("eve/__init__.py", "rt", encoding="utf8") as f:
     VERSION = re.search(r"__version__ = \"(.*?)\"", f.read()).group(1)
 
 INSTALL_REQUIRES = [
-    "cerberus>=1.2.cri.1.0",
+    "cerberus>=1.2+cri.1.0",
     "events>=0.3,<0.4",
     "flask>=1.0",
     "pymongo>=3.5",
     "simplejson>=3.3.0,<4.0",
 ]
 
-DEPENDENCY_LINKS = ["git+https://github.com/cri-dev/cerberus@1.2.cri.1.0"]
+DEPENDENCY_LINKS = [
+    "git+https://github.com/cri-dev/cerberus@1.2+cri.1.0#egg=Cerberus==1.2+cri.1.0"
+]
 
 EXTRAS_REQUIRE = {
     "docs": ["sphinx", "alabaster", "sphinxcontrib-embedly"],

--- a/setup.py
+++ b/setup.py
@@ -12,16 +12,14 @@ with io.open("eve/__init__.py", "rt", encoding="utf8") as f:
     VERSION = re.search(r"__version__ = \"(.*?)\"", f.read()).group(1)
 
 INSTALL_REQUIRES = [
-    "cerberus==1.2.cri",
+    "cerberus>=1.2-cri.1.0",
     "events>=0.3,<0.4",
     "flask>=1.0",
     "pymongo>=3.5",
     "simplejson>=3.3.0,<4.0",
 ]
 
-DEPENDENCY_LINKS = [
-    "git+https://github.com/cri-dev/cerberus@master#egg=Cerberus-1.2.cri"
-]
+DEPENDENCY_LINKS = ["git+https://github.com/cri-dev/cerberus@1.2-cri.1.0"]
 
 EXTRAS_REQUIRE = {
     "docs": ["sphinx", "alabaster", "sphinxcontrib-embedly"],

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with io.open("eve/__init__.py", "rt", encoding="utf8") as f:
     VERSION = re.search(r"__version__ = \"(.*?)\"", f.read()).group(1)
 
 INSTALL_REQUIRES = [
-    "cerberus==1.2+cri.1.0",
+    "cerberus>=1.2+cri.1.0",
     "events>=0.3,<0.4",
     "flask>=1.0",
     "pymongo>=3.5",

--- a/setup.py
+++ b/setup.py
@@ -12,12 +12,14 @@ with io.open("eve/__init__.py", "rt", encoding="utf8") as f:
     VERSION = re.search(r"__version__ = \"(.*?)\"", f.read()).group(1)
 
 INSTALL_REQUIRES = [
-    "cerberus>=1.1",
+    "cerberus==1.2.cri",
     "events>=0.3,<0.4",
     "flask>=1.0",
     "pymongo>=3.5",
     "simplejson>=3.3.0,<4.0",
 ]
+
+DEPENDENCY_LINKS = ["git+git://github.com/cri-dev/cerberus@master#egg=Cerberus-1.2.cri"]
 
 EXTRAS_REQUIRE = {
     "docs": ["sphinx", "alabaster", "sphinxcontrib-embedly"],
@@ -43,6 +45,7 @@ setup(
     packages=find_packages(),
     test_suite="eve.tests",
     install_requires=INSTALL_REQUIRES,
+    dependency_links=DEPENDENCY_LINKS,
     extras_require=EXTRAS_REQUIRE,
     python_requires=">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*",
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with io.open("eve/__init__.py", "rt", encoding="utf8") as f:
     VERSION = re.search(r"__version__ = \"(.*?)\"", f.read()).group(1)
 
 INSTALL_REQUIRES = [
-    "cerberus>=1.2+cri.1.0",
+    "cerberus==1.2+cri.1.0",
     "events>=0.3,<0.4",
     "flask>=1.0",
     "pymongo>=3.5",
@@ -20,7 +20,7 @@ INSTALL_REQUIRES = [
 ]
 
 DEPENDENCY_LINKS = [
-    "git+https://github.com/cri-dev/cerberus@1.2+cri.1.0#egg=Cerberus==1.2+cri.1.0"
+    "git+https://github.com/cri-dev/cerberus@1.2+cri.1.0#egg=cerberus-1.2+cri.1.0"
 ]
 
 EXTRAS_REQUIRE = {

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,9 @@ INSTALL_REQUIRES = [
     "simplejson>=3.3.0,<4.0",
 ]
 
-DEPENDENCY_LINKS = ["git+git://github.com/cri-dev/cerberus@master#egg=Cerberus-1.2.cri"]
+DEPENDENCY_LINKS = [
+    "git+https://github.com/cri-dev/cerberus@master#egg=Cerberus-1.2.cri"
+]
 
 EXTRAS_REQUIRE = {
     "docs": ["sphinx", "alabaster", "sphinxcontrib-embedly"],

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with io.open("eve/__init__.py", "rt", encoding="utf8") as f:
     VERSION = re.search(r"__version__ = \"(.*?)\"", f.read()).group(1)
 
 INSTALL_REQUIRES = [
-    "cerberus>=1.2+cri.1.0",
+    "cerberus>=1.2+cri.1.1",
     "events>=0.3,<0.4",
     "flask>=1.0",
     "pymongo>=3.5",
@@ -20,7 +20,7 @@ INSTALL_REQUIRES = [
 ]
 
 DEPENDENCY_LINKS = [
-    "git+https://github.com/cri-dev/cerberus@1.2+cri.1.0#egg=cerberus-1.2+cri.1.0"
+    "git+https://github.com/cri-dev/cerberus@1.2+cri.1.1#egg=cerberus-1.2+cri.1.1"
 ]
 
 EXTRAS_REQUIRE = {

--- a/setup.py
+++ b/setup.py
@@ -12,14 +12,14 @@ with io.open("eve/__init__.py", "rt", encoding="utf8") as f:
     VERSION = re.search(r"__version__ = \"(.*?)\"", f.read()).group(1)
 
 INSTALL_REQUIRES = [
-    "cerberus>=1.2-cri.1.0",
+    "cerberus>=1.2.cri.1.0",
     "events>=0.3,<0.4",
     "flask>=1.0",
     "pymongo>=3.5",
     "simplejson>=3.3.0,<4.0",
 ]
 
-DEPENDENCY_LINKS = ["git+https://github.com/cri-dev/cerberus@1.2-cri.1.0"]
+DEPENDENCY_LINKS = ["git+https://github.com/cri-dev/cerberus@1.2.cri.1.0"]
 
 EXTRAS_REQUIRE = {
     "docs": ["sphinx", "alabaster", "sphinxcontrib-embedly"],


### PR DESCRIPTION
This PR depends on the corresponding PR from [cerberus](https://github.com/pyeve/cerberus/pull/445).

I haven't created a test yet.  The idea is you define a resource like this:

```
medical_records = {
    'schema': {
        'name': {'type': 'string'},
        'aka': {'type': 'string'},
        'gender': {'type': 'string', 'allowed': ['male', 'female']},
        'admitted': {'type': 'date'},
        'discharged': {'type': 'date'},
        'is_pregnant': {'type': 'boolean'},
    },
    'document_validations': {'preg_check': True}
}
```

Add this to DOMAIN, then define a custom validator like this:
```
class MyValidator(Validator):
        def _validate_document_preg_check(self, preg_check, field, value):
            """ {'type': 'boolean'} """
            is_valid = True
            if self.document.get('is_pregnant'):
                is_valid = self.document.get('gender') == 'female'
            if not (preg_check and is_valid):
                self._error(field, 'Invalid: males cannot be pregnant')
```
