### PR TITLE
Move sort and where to functions

### DIFF
--- a/eve/io/mongo/mongo.py
+++ b/eve/io/mongo/mongo.py
@@ -37,6 +37,57 @@ from eve.utils import (
 )
 
 
+def convert_sort_request_to_dict(req):
+    """ Converts the contents of a `ParsedRequest`'s `sort` property to
+    a dict
+    """
+    client_sort = {}
+    if req and req.sort:
+        try:
+            # assume it's mongo syntax (ie. ?sort=[("name", 1)])
+            client_sort = ast.literal_eval(req.sort)
+        except ValueError:
+            # it's not mongo so let's see if it's a comma delimited string
+            # instead (ie. "?sort=-age, name").
+            sort = []
+            for sort_arg in [s.strip() for s in req.sort.split(",")]:
+                if sort_arg[0] == "-":
+                    sort.append((sort_arg[1:], -1))
+                else:
+                    sort.append((sort_arg, 1))
+            if len(sort) > 0:
+                client_sort = sort
+        except Exception as e:
+            self.app.logger.exception(e)
+            abort(400, description=debug_error_message(str(e)))
+    return client_sort
+
+
+def convert_where_request_to_dict(req):
+    """ Converts the contents of a `ParsedRequest`'s `where` property to
+    a dict
+    """
+    query = {}
+    if req and req.where:
+        try:
+            query = self._sanitize(json.loads(req.where))
+        except HTTPException as e:
+            # _sanitize() is raising an HTTP exception; let it fire.
+            raise
+        except:
+            # couldn't parse as mongo query; give the python parser a shot.
+            try:
+                query = parse(req.where)
+            except ParseError:
+                abort(
+                    400,
+                    description=debug_error_message(
+                        "Unable to parse `where` clause"
+                    ),
+                )
+    return query
+
+
 class MongoJSONEncoder(BaseJSONEncoder):
     """ Proprietary JSONEconder subclass used by the json render function.
     This is needed to address the encoding of special values.
@@ -209,45 +260,8 @@ class Mongo(DataLayer):
         # TODO should validate on unknown sort fields (mongo driver doesn't
         # return an error)
 
-        client_sort = {}
-        spec = {}
-
-        if req and req.sort:
-            try:
-                # assume it's mongo syntax (ie. ?sort=[("name", 1)])
-                client_sort = ast.literal_eval(req.sort)
-            except ValueError:
-                # it's not mongo so let's see if it's a comma delimited string
-                # instead (ie. "?sort=-age, name").
-                sort = []
-                for sort_arg in [s.strip() for s in req.sort.split(",")]:
-                    if sort_arg[0] == "-":
-                        sort.append((sort_arg[1:], -1))
-                    else:
-                        sort.append((sort_arg, 1))
-                if len(sort) > 0:
-                    client_sort = sort
-            except Exception as e:
-                self.app.logger.exception(e)
-                abort(400, description=debug_error_message(str(e)))
-
-        if req and req.where:
-            try:
-                spec = self._sanitize(json.loads(req.where))
-            except HTTPException as e:
-                # _sanitize() is raising an HTTP exception; let it fire.
-                raise
-            except:
-                # couldn't parse as mongo query; give the python parser a shot.
-                try:
-                    spec = parse(req.where)
-                except ParseError:
-                    abort(
-                        400,
-                        description=debug_error_message(
-                            "Unable to parse `where` clause"
-                        ),
-                    )
+        client_sort = convert_sort_request_to_dict(req)
+        spec = convert_where_request_to_dict(req)
 
         bad_filter = validate_filters(spec, resource)
         if bad_filter:

--- a/eve/io/mongo/mongo.py
+++ b/eve/io/mongo/mongo.py
@@ -37,57 +37,6 @@ from eve.utils import (
 )
 
 
-def convert_sort_request_to_dict(req):
-    """ Converts the contents of a `ParsedRequest`'s `sort` property to
-    a dict
-    """
-    client_sort = {}
-    if req and req.sort:
-        try:
-            # assume it's mongo syntax (ie. ?sort=[("name", 1)])
-            client_sort = ast.literal_eval(req.sort)
-        except ValueError:
-            # it's not mongo so let's see if it's a comma delimited string
-            # instead (ie. "?sort=-age, name").
-            sort = []
-            for sort_arg in [s.strip() for s in req.sort.split(",")]:
-                if sort_arg[0] == "-":
-                    sort.append((sort_arg[1:], -1))
-                else:
-                    sort.append((sort_arg, 1))
-            if len(sort) > 0:
-                client_sort = sort
-        except Exception as e:
-            self.app.logger.exception(e)
-            abort(400, description=debug_error_message(str(e)))
-    return client_sort
-
-
-def convert_where_request_to_dict(req):
-    """ Converts the contents of a `ParsedRequest`'s `where` property to
-    a dict
-    """
-    query = {}
-    if req and req.where:
-        try:
-            query = self._sanitize(json.loads(req.where))
-        except HTTPException as e:
-            # _sanitize() is raising an HTTP exception; let it fire.
-            raise
-        except:
-            # couldn't parse as mongo query; give the python parser a shot.
-            try:
-                query = parse(req.where)
-            except ParseError:
-                abort(
-                    400,
-                    description=debug_error_message(
-                        "Unable to parse `where` clause"
-                    ),
-                )
-    return query
-
-
 class MongoJSONEncoder(BaseJSONEncoder):
     """ Proprietary JSONEconder subclass used by the json render function.
     This is needed to address the encoding of special values.
@@ -260,8 +209,8 @@ class Mongo(DataLayer):
         # TODO should validate on unknown sort fields (mongo driver doesn't
         # return an error)
 
-        client_sort = convert_sort_request_to_dict(req)
-        spec = convert_where_request_to_dict(req)
+        client_sort = self._convert_sort_request_to_dict(req)
+        spec = self._convert_where_request_to_dict(req)
 
         bad_filter = validate_filters(spec, resource)
         if bad_filter:
@@ -883,6 +832,55 @@ class Mongo(DataLayer):
                 self._sanitize(value)
 
         return spec
+
+    def _convert_sort_request_to_dict(self, req):
+        """ Converts the contents of a `ParsedRequest`'s `sort` property to
+        a dict
+        """
+        client_sort = {}
+        if req and req.sort:
+            try:
+                # assume it's mongo syntax (ie. ?sort=[("name", 1)])
+                client_sort = ast.literal_eval(req.sort)
+            except ValueError:
+                # it's not mongo so let's see if it's a comma delimited string
+                # instead (ie. "?sort=-age, name").
+                sort = []
+                for sort_arg in [s.strip() for s in req.sort.split(",")]:
+                    if sort_arg[0] == "-":
+                        sort.append((sort_arg[1:], -1))
+                    else:
+                        sort.append((sort_arg, 1))
+                if len(sort) > 0:
+                    client_sort = sort
+            except Exception as e:
+                self.app.logger.exception(e)
+                abort(400, description=debug_error_message(str(e)))
+        return client_sort
+
+    def _convert_where_request_to_dict(self, req):
+        """ Converts the contents of a `ParsedRequest`'s `where` property to
+        a dict
+        """
+        query = {}
+        if req and req.where:
+            try:
+                query = self._sanitize(json.loads(req.where))
+            except HTTPException as e:
+                # _sanitize() is raising an HTTP exception; let it fire.
+                raise
+            except:
+                # couldn't parse as mongo query; give the python parser a shot.
+                try:
+                    query = parse(req.where)
+                except ParseError:
+                    abort(
+                        400,
+                        description=debug_error_message(
+                            "Unable to parse `where` clause"
+                        ),
+                    )
+        return query
 
     def _wc(self, resource):
         """ Syntactic sugar for the current collection write_concern setting.


### PR DESCRIPTION
### Purpose
Make the parsing of `req.sort` and `req.where` easily reusable to support addition of `where` functionality to DELETE and PATCH requests on resource endpoints.  These updates will be provided in subsequent pull requests.

### Changes
These changes simply copy functionality for parsing `req.sort` and `req.where` from `Mongo.find()` to two new methods: `Mongo._convert_sort_request_to_dict()` and `Mongo._convert_where_request_to_dict()`.

The new functions are exact copies of the code that had been in `Mongo.find()` and introduce no new code.

### Tests
No new code has been added, code has only been moved.  No new tests are required and all tests pass for Python 2.7.15, 3.4.6, 3.5.6, 3.6.6, and Pypy with the exception of the test referenced in #1193.