### PR TITLE
Feature new event hook for diffs

### DIFF
--- a/docs/features.rst
+++ b/docs/features.rst
@@ -1270,6 +1270,12 @@ Let's see an overview of what events are available:
 |       |        |      +--------------------------------------------------+
 |       |        |      || ``on_fetched_item_<resource_name>``             |
 |       |        |      || ``def event(response)``                         |
+|       +--------+------+--------------------------------------------------+
+|       |Diffs   |After || ``on_fetched_diffs``                            |
+|       |        |      || ``def event(resource_name, response)``          |
+|       |        |      +--------------------------------------------------+
+|       |        |      || ``on_fetched_diffs_<resource_name>``            |
+|       |        |      || ``def event(response)``                         |
 +-------+--------+------+--------------------------------------------------+
 |Insert |Items   |Before|| ``on_insert``                                   |
 |       |        |      || ``def event(resource_name, items)``             |
@@ -1349,6 +1355,8 @@ These are the fetch events with their method signature:
 - ``on_fetched_resource_<resource_name>(response)``
 - ``on_fetched_item(resource_name, response)``
 - ``on_fetched_item_<resource_name>(response)``
+- ``on_fetched_diffs(resource_name, response)``
+- ``on_fetched_diffs_<resource_name>(response)``
 
 They are raised when items have just been read from the database and are
 about to be sent to the client. Registered callback functions can manipulate
@@ -1374,12 +1382,12 @@ the items as needed before they are returned to the client.
     >>> app.on_fetched_item += before_returning_item
     >>> app.on_fetched_item_contacts += before_returning_contact
 
-It is important to note that fetch events will work with `Document
-Versioning`_ for specific document versions like ``?version=5``, accessing all
-document versions with ``?version=all``, and accessing diffs of all versions
-with ``?version=diffs``. When working with versioning, care should be taken in
-the registered callback to handle possible schema differences or partial
-documents. Diffs by design is partial documents.
+It is important to note that item fetch events will work with `Document
+Versioning`_ for specific document versions like ``?version=5`` and all
+document versions with ``?version=all``. Accessing diffs of all versions
+with ``?version=diffs`` will only work with the diffs fetch events. Note
+that diffs returns partial documents which should be handled in the
+callback.
 
 
 Insert Events

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -1375,9 +1375,11 @@ the items as needed before they are returned to the client.
     >>> app.on_fetched_item_contacts += before_returning_contact
 
 It is important to note that fetch events will work with `Document
-Versioning`_ for specific document versions or accessing all document
-versions with ``?version=all``, but they *will not* work when accessing diffs
-of all versions with ``?version=diffs``.
+Versioning`_ for specific document versions like ``?version=5``, accessing all
+document versions with ``?version=all``, and accessing diffs of all versions
+with ``?version=diffs``. When working with versioning, care should be taken in
+the registered callback to handle possible schema differences or partial
+documents. Diffs by design is partial documents.
 
 
 Insert Events

--- a/eve/methods/get.py
+++ b/eve/methods/get.py
@@ -480,8 +480,12 @@ def getitem_internal(resource, **lookup):
         if config.DOMAIN[resource]["hateoas"]:
             versions = response[config.ITEMS]
         for version_item in versions:
-            getattr(app, "on_fetched_item")(resource, version_item)
-            getattr(app, "on_fetched_item_%s" % resource)(version_item)
+            if version == "diffs":
+                getattr(app, "on_fetched_diffs")(resource, version_item)
+                getattr(app, "on_fetched_diffs_%s" % resource)(version_item)
+            else:
+                getattr(app, "on_fetched_item")(resource, version_item)
+                getattr(app, "on_fetched_item_%s" % resource)(version_item)
     else:
         getattr(app, "on_fetched_item")(resource, response)
         getattr(app, "on_fetched_item_%s" % resource)(response)

--- a/eve/methods/get.py
+++ b/eve/methods/get.py
@@ -468,24 +468,23 @@ def getitem_internal(resource, **lookup):
                 resource, req, None, response[resource_def["id_field"]]
             )
 
-    # callbacks not supported on version diffs because of partial documents
-    if version != "diffs":
-        # TODO: callbacks not currently supported with ?version=all
-
-        # notify registered callback functions. Please note that, should
-        # the functions modify the document, last_modified and etag
-        # won't be updated to reflect the changes (they always reflect the
-        # documents state on the database).
-        if resource_def["versioning"] is True and version == "all":
-            versions = response
-            if config.DOMAIN[resource]["hateoas"]:
-                versions = response[config.ITEMS]
-            for version_item in versions:
-                getattr(app, "on_fetched_item")(resource, version_item)
-                getattr(app, "on_fetched_item_%s" % resource)(version_item)
-        else:
-            getattr(app, "on_fetched_item")(resource, response)
-            getattr(app, "on_fetched_item_%s" % resource)(response)
+    # callbacks supported on all version methods - even for diffs with partial documents
+    # partial documents should be handled properly in the callback
+    #
+    # notify registered callback functions. Please note that, should
+    # the functions modify the document, last_modified and etag
+    # won't be updated to reflect the changes (they always reflect the
+    # documents state on the database).
+    if resource_def["versioning"] is True and version in ["all", "diffs"]:
+        versions = response
+        if config.DOMAIN[resource]["hateoas"]:
+            versions = response[config.ITEMS]
+        for version_item in versions:
+            getattr(app, "on_fetched_item")(resource, version_item)
+            getattr(app, "on_fetched_item_%s" % resource)(version_item)
+    else:
+        getattr(app, "on_fetched_item")(resource, response)
+        getattr(app, "on_fetched_item_%s" % resource)(response)
 
     return response, last_modified, etag, 200
 

--- a/eve/tests/versioning.py
+++ b/eve/tests/versioning.py
@@ -478,7 +478,7 @@ class TestCompleteVersioning(TestNormalVersioning):
         response, status = self.get(
             self.known_resource, item=self.item_id, query="?version=diffs"
         )
-        self.assertEqual(2, len(devent.called))
+        self.assertEqual(None, devent.called)
 
     def test_on_fetched_item_contacts(self):
         """ Verify that on_fetched_item_contacts events are fired for versioned
@@ -500,6 +500,68 @@ class TestCompleteVersioning(TestNormalVersioning):
         )
         self.assertEqual(self.item_id, str(devent.called[0][self.id_field]))
         self.assertEqual(1, len(devent.called))
+
+        # check for ?version=diffs requests
+        devent = DummyEvent(lambda: True)
+        self.app.on_fetched_item_contacts += devent
+        response, status = self.get(
+            self.known_resource, item=self.item_id, query="?version=diffs"
+        )
+        self.assertEqual(None, devent.called)
+
+        # TODO: also test with HATEOS off
+
+    def test_on_fetched_diffs(self):
+        """ Verify that on_fetched_item events are fired for versioned
+        requests.
+        """
+        devent = DummyEvent(lambda: True)
+        self.app.on_fetched_item += devent
+        response, status = self.get(
+            self.known_resource, item=self.item_id, query="?version=1"
+        )
+        self.assertEqual(self.known_resource, devent.called[0])
+        self.assertEqual(self.item_id, str(devent.called[1][self.id_field]))
+        self.assertEqual(None, devent.called)
+
+        # check for ?version=all requests
+        devent = DummyEvent(lambda: True)
+        self.app.on_fetched_item += devent
+        response, status = self.get(
+            self.known_resource, item=self.item_id, query="?version=all"
+        )
+        self.assertEqual(self.known_resource, devent.called[0])
+        self.assertEqual(self.item_id, str(devent.called[1][self.id_field]))
+        self.assertEqual(None, devent.called)
+
+        # check for ?version=diffs requests
+        devent = DummyEvent(lambda: True)
+        self.app.on_fetched_item += devent
+        response, status = self.get(
+            self.known_resource, item=self.item_id, query="?version=diffs"
+        )
+        self.assertEqual(2, len(devent.called))
+
+    def test_on_fetched_diffs_contacts(self):
+        """ Verify that on_fetched_item_contacts events are fired for versioned
+        requests.
+        """
+        devent = DummyEvent(lambda: True)
+        self.app.on_fetched_item_contacts += devent
+        response, status = self.get(
+            self.known_resource, item=self.item_id, query="?version=1"
+        )
+        self.assertEqual(self.item_id, str(devent.called[0][self.id_field]))
+        self.assertEqual(None, devent.called)
+
+        # check for ?version=all requests
+        devent = DummyEvent(lambda: True)
+        self.app.on_fetched_item_contacts += devent
+        response, status = self.get(
+            self.known_resource, item=self.item_id, query="?version=all"
+        )
+        self.assertEqual(self.item_id, str(devent.called[0][self.id_field]))
+        self.assertEqual(None, devent.called)
 
         # check for ?version=diffs requests
         devent = DummyEvent(lambda: True)

--- a/eve/tests/versioning.py
+++ b/eve/tests/versioning.py
@@ -564,7 +564,7 @@ class TestCompleteVersioning(TestNormalVersioning):
         response, status = self.get(
             self.known_resource, item=self.item_id, query="?version=diffs"
         )
-        self.assertEqual(self.known_resource, devent.called[0])
+        self.assertEqual(self.item_id, str(devent.called[0][self.id_field]))
         self.assertEqual(1, len(devent.called))
 
         # TODO: also test with HATEOS off

--- a/eve/tests/versioning.py
+++ b/eve/tests/versioning.py
@@ -478,7 +478,7 @@ class TestCompleteVersioning(TestNormalVersioning):
         response, status = self.get(
             self.known_resource, item=self.item_id, query="?version=diffs"
         )
-        self.assertEqual(None, devent.called)
+        self.assertEqual(2, len(devent.called))
 
     def test_on_fetched_item_contacts(self):
         """ Verify that on_fetched_item_contacts events are fired for versioned
@@ -507,7 +507,7 @@ class TestCompleteVersioning(TestNormalVersioning):
         response, status = self.get(
             self.known_resource, item=self.item_id, query="?version=diffs"
         )
-        self.assertEqual(None, devent.called)
+        self.assertEqual(1, len(devent.called))
 
         # TODO: also test with HATEOS off
 

--- a/eve/tests/versioning.py
+++ b/eve/tests/versioning.py
@@ -512,63 +512,59 @@ class TestCompleteVersioning(TestNormalVersioning):
         # TODO: also test with HATEOS off
 
     def test_on_fetched_diffs(self):
-        """ Verify that on_fetched_item events are fired for versioned
-        requests.
+        """ Verify that on_fetched_item events are fired for
+        version=diffs requests.
         """
         devent = DummyEvent(lambda: True)
-        self.app.on_fetched_item += devent
+        self.app.on_fetched_diffs += devent
         response, status = self.get(
             self.known_resource, item=self.item_id, query="?version=1"
         )
-        self.assertEqual(self.known_resource, devent.called[0])
-        self.assertEqual(self.item_id, str(devent.called[1][self.id_field]))
         self.assertEqual(None, devent.called)
 
         # check for ?version=all requests
         devent = DummyEvent(lambda: True)
-        self.app.on_fetched_item += devent
+        self.app.on_fetched_diffs += devent
         response, status = self.get(
             self.known_resource, item=self.item_id, query="?version=all"
         )
-        self.assertEqual(self.known_resource, devent.called[0])
-        self.assertEqual(self.item_id, str(devent.called[1][self.id_field]))
         self.assertEqual(None, devent.called)
 
         # check for ?version=diffs requests
         devent = DummyEvent(lambda: True)
-        self.app.on_fetched_item += devent
+        self.app.on_fetched_diffs += devent
         response, status = self.get(
             self.known_resource, item=self.item_id, query="?version=diffs"
         )
+        self.assertEqual(self.known_resource, devent.called[0])
         self.assertEqual(2, len(devent.called))
 
     def test_on_fetched_diffs_contacts(self):
-        """ Verify that on_fetched_item_contacts events are fired for versioned
-        requests.
+        """ Verify that on_fetched_diffs_contacts events are fired for
+        version=diffs requests.
         """
         devent = DummyEvent(lambda: True)
-        self.app.on_fetched_item_contacts += devent
+        self.app.on_fetched_diffs_contacts += devent
         response, status = self.get(
             self.known_resource, item=self.item_id, query="?version=1"
         )
-        self.assertEqual(self.item_id, str(devent.called[0][self.id_field]))
         self.assertEqual(None, devent.called)
 
         # check for ?version=all requests
         devent = DummyEvent(lambda: True)
-        self.app.on_fetched_item_contacts += devent
+        self.app.on_fetched_diffs_contacts += devent
         response, status = self.get(
             self.known_resource, item=self.item_id, query="?version=all"
         )
-        self.assertEqual(self.item_id, str(devent.called[0][self.id_field]))
         self.assertEqual(None, devent.called)
 
         # check for ?version=diffs requests
         devent = DummyEvent(lambda: True)
-        self.app.on_fetched_item_contacts += devent
+        self.app.on_fetched_diffs_contacts += devent
         response, status = self.get(
             self.known_resource, item=self.item_id, query="?version=diffs"
         )
+        self.assertEqual(self.known_resource, devent.called[0])
         self.assertEqual(1, len(devent.called))
 
         # TODO: also test with HATEOS off


### PR DESCRIPTION
To plug the hole left from not having event hooks fire on diffs. A use case could be anonymizing documents via `on_fetched_*`. Accessing with `version=diffs` would expose the documents. 

This alternative introduces `on_fetched_diff`event hooks to allow wiring up  `version=diffs`