### PR TITLE
Allow event fetched on diffs#475

### DIFF
--- a/docs/features.rst
+++ b/docs/features.rst
@@ -1375,9 +1375,11 @@ the items as needed before they are returned to the client.
     >>> app.on_fetched_item_contacts += before_returning_contact
 
 It is important to note that fetch events will work with `Document
-Versioning`_ for specific document versions or accessing all document
-versions with ``?version=all``, but they *will not* work when accessing diffs
-of all versions with ``?version=diffs``.
+Versioning`_ for specific document versions like ``?version=5``, accessing all
+document versions with ``?version=all``, and accessing diffs of all versions
+with ``?version=diffs``. When working with versioning, care should be taken in
+the registered callback to handle possible schema differences or partial
+documents. Diffs by design is partial documents.
 
 
 Insert Events

--- a/eve/methods/get.py
+++ b/eve/methods/get.py
@@ -468,24 +468,23 @@ def getitem_internal(resource, **lookup):
                 resource, req, None, response[resource_def["id_field"]]
             )
 
-    # callbacks not supported on version diffs because of partial documents
-    if version != "diffs":
-        # TODO: callbacks not currently supported with ?version=all
-
-        # notify registered callback functions. Please note that, should
-        # the functions modify the document, last_modified and etag
-        # won't be updated to reflect the changes (they always reflect the
-        # documents state on the database).
-        if resource_def["versioning"] is True and version == "all":
-            versions = response
-            if config.DOMAIN[resource]["hateoas"]:
-                versions = response[config.ITEMS]
-            for version_item in versions:
-                getattr(app, "on_fetched_item")(resource, version_item)
-                getattr(app, "on_fetched_item_%s" % resource)(version_item)
-        else:
-            getattr(app, "on_fetched_item")(resource, response)
-            getattr(app, "on_fetched_item_%s" % resource)(response)
+    # callbacks supported on all version methods - even for diffs with partial documents
+    # partial documents should be handled properly in the callback
+    #
+    # notify registered callback functions. Please note that, should
+    # the functions modify the document, last_modified and etag
+    # won't be updated to reflect the changes (they always reflect the
+    # documents state on the database).
+    if resource_def["versioning"] is True and version in ["all", "diffs"]:
+        versions = response
+        if config.DOMAIN[resource]["hateoas"]:
+            versions = response[config.ITEMS]
+        for version_item in versions:
+            getattr(app, "on_fetched_item")(resource, version_item)
+            getattr(app, "on_fetched_item_%s" % resource)(version_item)
+    else:
+        getattr(app, "on_fetched_item")(resource, response)
+        getattr(app, "on_fetched_item_%s" % resource)(response)
 
     return response, last_modified, etag, 200
 

--- a/eve/tests/versioning.py
+++ b/eve/tests/versioning.py
@@ -478,7 +478,7 @@ class TestCompleteVersioning(TestNormalVersioning):
         response, status = self.get(
             self.known_resource, item=self.item_id, query="?version=diffs"
         )
-        self.assertEqual(None, devent.called)
+        self.assertEqual(2, len(devent.called))
 
     def test_on_fetched_item_contacts(self):
         """ Verify that on_fetched_item_contacts events are fired for versioned
@@ -507,7 +507,7 @@ class TestCompleteVersioning(TestNormalVersioning):
         response, status = self.get(
             self.known_resource, item=self.item_id, query="?version=diffs"
         )
-        self.assertEqual(None, devent.called)
+        self.assertEqual(1, len(devent.called))
 
         # TODO: also test with HATEOS off
 


### PR DESCRIPTION
See PR #1223 for the other alternative introducing `on_fetched_diffs`.

This PR allows `version=diffs` to run when `on_fetched*` event hooks are wired up.

This makes all item and resource fetches fire the callback. A use case could be anonymizing documents via on_fetched_*. Accessing with version=diffs would expose the documents.

As discussed in #475 and inline code notes `version=diffs` will return partial documents which can have unexpected results if it's not handled correctly in the callback.

