### PR TITLE
Deprecation warning newer pymongo #1202

### DIFF
--- a/eve/default_settings.py
+++ b/eve/default_settings.py
@@ -11,6 +11,8 @@
     :copyright: (c) 2017 by Nicola Iarocci.
     :license: BSD, see LICENSE for more details.
 
+    .. versionchanged:: 0.8.2
+        'PAGINATION_STRATEGY' options are None, full and estimate and set to full.
     .. versionchanged:: 0.8
         'RENDERERS' added with XML and JSON renderers.
         'JSON' removed.
@@ -164,6 +166,9 @@ PROJECTION = True  # projection enabled by default
 PAGINATION = True  # pagination enabled by default.
 PAGINATION_LIMIT = 50
 PAGINATION_DEFAULT = 25
+HEADER_TOTAL_COUNT = "X-Total-Count"
+PAGINATION_STRATEGY = "full"
+OPTIMIZE_PAGINATION_FOR_SPEED = False
 VERSIONING = False  # turn document versioning on or off.
 VERSIONS = "_versions"  # suffix for parallel collection w/old versions
 VERSION_PARAM = "version"  # URL param for specific version of a document.
@@ -237,9 +242,6 @@ QUERY_PAGE = "page"
 QUERY_MAX_RESULTS = "max_results"
 QUERY_EMBEDDED = "embedded"
 QUERY_AGGREGATION = "aggregate"
-
-HEADER_TOTAL_COUNT = "X-Total-Count"
-OPTIMIZE_PAGINATION_FOR_SPEED = False
 
 # user-restricted resource access is disabled by default.
 AUTH_FIELD = None

--- a/eve/default_settings.py
+++ b/eve/default_settings.py
@@ -167,7 +167,13 @@ PAGINATION = True  # pagination enabled by default.
 PAGINATION_LIMIT = 50
 PAGINATION_DEFAULT = 25
 HEADER_TOTAL_COUNT = "X-Total-Count"
+
+# http://api.mongodb.com/python/current/api/pymongo/collection.html
+# full=count_documents(filter, session=None, **kwargs) interesting options are hint=index name or index spec and maxTimeMS
+# estimated=estimated_document_count(**kwargs) also maxTimeMS can be given!
+# None=None
 PAGINATION_STRATEGY = "full"
+
 OPTIMIZE_PAGINATION_FOR_SPEED = False
 VERSIONING = False  # turn document versioning on or off.
 VERSIONS = "_versions"  # suffix for parallel collection w/old versions

--- a/eve/io/mongo/mongo.py
+++ b/eve/io/mongo/mongo.py
@@ -294,7 +294,7 @@ class Mongo(DataLayer):
                 self.pymongo(resource).db[datasource].find(**args),
             )
         else:
-            return (None, self.pymongo(resource).db[datasource].find(**args))
+            return None, self.pymongo(resource).db[datasource].find(**args)
 
     def find_one(
         self,

--- a/eve/io/mongo/mongo.py
+++ b/eve/io/mongo/mongo.py
@@ -272,9 +272,7 @@ class Mongo(DataLayer):
             )
         elif pagination_strategy == "estimated":
             return (
-                self.pymongo(resource)
-                .db[datasource]
-                .estimated_document_count(filter=args["filter"]),
+                self.pymongo(resource).db[datasource].estimated_document_count(),
                 self.pymongo(resource).db[datasource].find(**args),
             )
         else:

--- a/eve/io/mongo/mongo.py
+++ b/eve/io/mongo/mongo.py
@@ -254,19 +254,43 @@ class Mongo(DataLayer):
             args["projection"] = projection
 
         # PAGINATION STRATEGY for resource
-        if config.DOMAIN[resource]["pagination_strategy"] is not None:
+        if config.DOMAIN[resource].get("pagination_strategy", None) is not None:
             pagination_strategy = config.DOMAIN[resource]["pagination_strategy"]
         elif config.PAGINATION_STRATEGY is not None:
             pagination_strategy = config.PAGINATION_STRATEGY
+        else:
+            pagination_strategy = None
+
+        if pagination_strategy is not None:
+            args_count = args.copy()
+            args_count.pop("sort", None)
+            args_count.pop("projection", None)
+            args_count.pop("limit", None)
+            if "filter" not in args_count:
+                args_count["filter"] = {}
+
+            # Operator    Replacement
+            # $where    $expr
+            # $near    $geoWithin with $center
+            # $nearSphere    $geoWithin with $centerSphere
+            # args_count["filter"] = args_count["filter"].replace("$where", "$expr", 1)
+            # args_count["filter"].replace("$geoWithin", "$center")
+            # args_count["filter"].replace("$where", "$expr")
+
+            print("COUNT", args_count)
+            print("ARGS ", args)
+            # args_count.pop("sort", None)
 
         if pagination_strategy == "full":
             return (
-                self.pymongo(resource).db[datasource].count_documents(**args),
+                self.pymongo(resource).db[datasource].count_documents(**args_count),
                 self.pymongo(resource).db[datasource].find(**args),
             )
         elif pagination_strategy == "estimated":
             return (
-                self.pymongo(resource).db[datasource].estimated_document_count(**args),
+                self.pymongo(resource)
+                .db[datasource]
+                .estimated_document_count(**args_count),
                 self.pymongo(resource).db[datasource].find(**args),
             )
         else:

--- a/eve/io/mongo/mongo.py
+++ b/eve/io/mongo/mongo.py
@@ -253,44 +253,26 @@ class Mongo(DataLayer):
         if projection:
             args["projection"] = projection
 
-        # PAGINATION STRATEGY for resource
+        # pagination_strategy for resource
         if config.DOMAIN[resource].get("pagination_strategy", None) is not None:
             pagination_strategy = config.DOMAIN[resource]["pagination_strategy"]
+        # Global PAGINATION_STRATEGY
         elif config.PAGINATION_STRATEGY is not None:
             pagination_strategy = config.PAGINATION_STRATEGY
         else:
             pagination_strategy = None
 
-        if pagination_strategy is not None:
-            args_count = args.copy()
-            args_count.pop("sort", None)
-            args_count.pop("projection", None)
-            args_count.pop("limit", None)
-            if "filter" not in args_count:
-                args_count["filter"] = {}
-
-            # Operator    Replacement
-            # $where    $expr
-            # $near    $geoWithin with $center
-            # $nearSphere    $geoWithin with $centerSphere
-            # args_count["filter"] = args_count["filter"].replace("$where", "$expr", 1)
-            # args_count["filter"].replace("$geoWithin", "$center")
-            # args_count["filter"].replace("$where", "$expr")
-
-            print("COUNT", args_count)
-            print("ARGS ", args)
-            # args_count.pop("sort", None)
-
+        # Execute strategy
         if pagination_strategy == "full":
             return (
-                self.pymongo(resource).db[datasource].count_documents(**args_count),
+                self.pymongo(resource).db[datasource].count_documents(**args["filter"]),
                 self.pymongo(resource).db[datasource].find(**args),
             )
         elif pagination_strategy == "estimated":
             return (
                 self.pymongo(resource)
                 .db[datasource]
-                .estimated_document_count(**args_count),
+                .estimated_document_count(**args["filter"]),
                 self.pymongo(resource).db[datasource].find(**args),
             )
         else:

--- a/eve/io/mongo/mongo.py
+++ b/eve/io/mongo/mongo.py
@@ -265,14 +265,16 @@ class Mongo(DataLayer):
         # Execute strategy
         if pagination_strategy == "full":
             return (
-                self.pymongo(resource).db[datasource].count_documents(**args["filter"]),
+                self.pymongo(resource)
+                .db[datasource]
+                .count_documents(filter=args["filter"]),
                 self.pymongo(resource).db[datasource].find(**args),
             )
         elif pagination_strategy == "estimated":
             return (
                 self.pymongo(resource)
                 .db[datasource]
-                .estimated_document_count(**args["filter"]),
+                .estimated_document_count(filter=args["filter"]),
                 self.pymongo(resource).db[datasource].find(**args),
             )
         else:

--- a/eve/io/mongo/mongo.py
+++ b/eve/io/mongo/mongo.py
@@ -263,11 +263,11 @@ class Mongo(DataLayer):
             pagination_strategy = None
 
         # Execute strategy
-        if pagination_strategy == "full":
+        if pagination_strategy == "full" or (
+            pagination_strategy == "estimated" and len(spec) > 0
+        ):
             return (
-                self.pymongo(resource)
-                .db[datasource]
-                .count_documents(filter=args["filter"]),
+                self.pymongo(resource).db[datasource].count_documents(filter=spec),
                 self.pymongo(resource).db[datasource].find(**args),
             )
         elif pagination_strategy == "estimated":

--- a/eve/methods/get.py
+++ b/eve/methods/get.py
@@ -405,11 +405,11 @@ def getitem_internal(resource, **lookup):
             # default sort for 'all', required sort for 'diffs'
             req.sort = '[("%s", 1)]' % config.VERSION
         req.if_modified_since = None  # we always want the full history here
-        cursor = app.data.find(resource + config.VERSIONS, req, lookup)
+        count, cursor = app.data.find(resource + config.VERSIONS, req, lookup)
 
         # build all versions
         documents = []
-        if cursor.count() == 0:
+        if count == 0:
             # this is the scenario when the document existed before
             # document versioning got turned on
             documents.append(latest_doc)
@@ -461,7 +461,6 @@ def getitem_internal(resource, **lookup):
     if config.DOMAIN[resource]["hateoas"]:
         # use the id of the latest document for multi-document requests
         if cursor:
-            count = cursor.count(with_limit_and_skip=False)
             response[config.LINKS] = _pagination_links(
                 resource, req, count, latest_doc[resource_def["id_field"]]
             )

--- a/eve/methods/get.py
+++ b/eve/methods/get.py
@@ -213,7 +213,7 @@ def _perform_find(resource, lookup):
     # If-Modified-Since disabled on collections (#334)
     req.if_modified_since = None
 
-    cursor = app.data.find(resource, req, lookup)
+    count, cursor = app.data.find(resource, req, lookup)
     # If soft delete is enabled, data.find will not include items marked
     # deleted unless req.show_deleted is True
     for document in cursor:
@@ -230,10 +230,13 @@ def _perform_find(resource, lookup):
 
     response[config.ITEMS] = documents
 
+    """
     if config.OPTIMIZE_PAGINATION_FOR_SPEED:
         count = None
     else:
         count = cursor.count(with_limit_and_skip=False)
+    """
+    if count is not None:
         headers.append((config.HEADER_TOTAL_COUNT, count))
 
     if config.DOMAIN[resource]["hateoas"]:

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ INSTALL_REQUIRES = [
     "cerberus>=1.1",
     "events>=0.3,<0.4",
     "flask>=1.0",
-    "pymongo>=3.5",
+    "pymongo>=3.7",
     "simplejson>=3.3.0,<4.0",
 ]
 


### PR DESCRIPTION
PR to get some comments on the implementation ref discussion for #1202.  No tests yet.

Main takeaways are:

- needs pymongo>=3.7
- breaks datalayer `find()` return signature from `cursor` to `count, cursor`
- introduces new global config setting `PAGINATION_STRATEGY` and per resource `pagination_strategy`

 `PAGINATION_STRATEGY` will probably make `OPTIMIZE_PAGINATION_FOR_SPEED` obsolete. Options are

- `None` no count
- `full` pymongos `count_documents` which do an aggregation query over all documents hence is accurate, equivalent to deprecated `cursor.count()`
- `estimated` pymongos `estimated_document_count` which estimates the number of documents based on collection statistics

I haven't tried  `count_documents` hint and max execution time options, could possibly be something to investigate?

I did some simple benchmarks with wrk. On the smaller collections there is not much difference, but it's appearent that `count_documents` becomes increasingly slower with collection size.

On this PR,  `PAGINATION_STRATEGY`:

- `None` 216 requests in 20.02s
- `estimated` 191 requests in 20.03s
- `full` 9 requests in 20.04s

On pyeve/master,  `OPTIMIZE_PAGINATION_FOR_SPEED`:

- `False` 9 requests in 20.03s
- `True` 206 requests in 20.03s

Tests done on an indexed collection just shy of 5m documents, one connection, to be taken as an indication only.

I did observe `estimated` to be accurate on all requests. Also, the very first database hit for `estimated` takes around 1/3 of the time of an `full` then drops by a factor of 10 and is constant for all following requests. I assume that `estimated` will be accurate and almost as fast as no counting for large collections with few updates. With frequent updates it would probably become slower but still a lot faster than doing the `full` count. I don't know about accuracy on frequent updates.

I think this could be of great use especially for those with large collections.

Feedback appreciated!











