### PR TITLE
Added VERSION_PARAM to default_params

### DIFF
--- a/eve/methods/get.py
+++ b/eve/methods/get.py
@@ -631,6 +631,7 @@ def _other_params(args):
         config.QUERY_MAX_RESULTS,
         config.QUERY_EMBEDDED,
         config.QUERY_PROJECTION,
+        config.VERSION_PARAM,
     ]
     return MultiDict(
         (key, value)


### PR DESCRIPTION
See discussion in #1224, VERSION_PARAM missing and ends up being added to other params resulting in a double `&version=diffs&version=diffs` in `_links`