### PR TITLE
To be compatible with werkzeug version 0.15.1

### DIFF
--- a/eve/auth.py
+++ b/eve/auth.py
@@ -146,10 +146,7 @@ class BasicAuth(object):
         """ Returns a standard a 401 response that enables basic auth.
         Override if you want to change the response and/or the realm.
         """
-        resp = Response(
-            None, 401, {"WWW-Authenticate": 'Basic realm="%s"' % __package__}
-        )
-        abort(401, description="Please provide proper credentials", response=resp)
+        abort(401, description="Please provide proper credentials")
 
     def authorized(self, allowed_roles, resource, method):
         """ Validates the the current request is allowed to pass through.


### PR DESCRIPTION
In werkzeug version 0.15.1, response automatically include WWW-Authenticate header and they don't accept response argument anymore which is crashing when you add Auth in your domain and it is being unauthenticated. 