### PR TITLE
docs, not valid python

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -1161,7 +1161,7 @@ streams.
 ::
 
     # 'people' schema definition
-    'schema'= {
+    schema = {
         'firstname': {
             'type': 'string',
             'minlength': 1,


### PR DESCRIPTION
can't assign to literal