### PR TITLE
Fix inconsistent DBRef format between GET and PUT

### DIFF
--- a/eve/io/mongo/mongo.py
+++ b/eve/io/mongo/mongo.py
@@ -94,7 +94,9 @@ class Mongo(DataLayer):
             str(v).lower()
         ],
         "dbref": lambda value: DBRef(
-            value["$col"], value["$id"], value["$db"] if "$db" in value else None
+            value["$col"] if "$col" in value else value["$ref"],
+            value["$id"],
+            value["$db"] if "$db" in value else None,
         )
         if value is not None
         else None,


### PR DESCRIPTION
Closes #1216 

According to the MongoDB Manual https://docs.mongodb.com/manual/reference/database-references/#dbrefs DBRef documents resemble the following format { "**$ref**" : <value>, "$id" : <value>, "$db" : <value> }

Currently Eve conforms to that format only when processing a GET request. In PUT request, it will use { "**$col**" : <value>, "$id" : <value> }. The client needs to perform additional handling to convert data before a PUT request.

In this PR PUT request supports { "**$ref**" : <value>, "$id" : <value> } which is consistent with GET response. It is also backward compatible with the old { "**$col**" : <value>, "$id" : <value> } way.