### PR TITLE
Do not crash without www-authentication header

### DIFF
--- a/eve/endpoints.py
+++ b/eve/endpoints.py
@@ -170,7 +170,8 @@ def error_endpoint(error):
         pass
 
     try:
-        headers.append(error.www_authenticate)
+        if error.www_authenticate != (None,):
+            headers.append(error.www_authenticate)
     except AttributeError:
         pass
 


### PR DESCRIPTION
Currently, there is an issue with `abort(401)`. Per default,the keyword argument `www_authenticate` is `None` for the `UnauthorizedException`, i.e. `abort(401)` (as described in the [Werkzeug docs](https://werkzeug.palletsprojects.com/en/0.15.x/exceptions/#error-classes)), and the resulting exception attribute is `e.www-authenticate = (None,)`.

In [endpoints.py#L173](https://github.com/pyeve/eve/blob/master/eve/endpoints.py#L173), this `(None,)` is added to the header stack, which crashes response processing in [render.py#L164](https://github.com/pyeve/eve/blob/master/eve/render.py#L164), as `(None,)` cannot be unpacked to `header, value`.

In our API, an automated basic auth response does not make sense, yet calling `abort(401)` (without the `www_authenticate`) is currently impossible with Eve.

In this PR, I have modified the error endpoint to only add the `www_authenticate` header if it is a proper `header, value` pair and not the `(None,)` default.

I'd love to add a test as well, but I don't quite know where in the test suite this would fit in best. Any pointers are appreciated, and I'll get to it.