### PR TITLE
Return 400 if update/replace with malformed DBRef field.

### DIFF
--- a/eve/io/mongo/mongo.py
+++ b/eve/io/mongo/mongo.py
@@ -66,7 +66,7 @@ class MongoJSONEncoder(BaseJSONEncoder):
             retval["$id"] = str(obj.id)
             if obj.database:
                 retval["$db"] = obj.database
-            return retval
+            return json.RawJSON(json.dumps(retval))
         if isinstance(obj, decimal128.Decimal128):
             return str(obj)
         # delegate rendering to base class method

--- a/eve/io/mongo/mongo.py
+++ b/eve/io/mongo/mongo.py
@@ -495,6 +495,9 @@ class Mongo(DataLayer):
     def _change_request(self, resource, id_, changes, original, replace=False):
         """ Performs a change, be it a replace or update.
 
+        .. versionchanged:: 0.8.2
+           Return 400 if update/replace with malformed DBRef field. See #1257.
+
         .. versionchanged:: 0.6.1
            Support for PyMongo 3.0.
 
@@ -528,6 +531,13 @@ class Mongo(DataLayer):
                 400,
                 description=debug_error_message(
                     "pymongo.errors.DuplicateKeyError: %s" % e
+                ),
+            )
+        except pymongo.errors.WriteError as e:
+            abort(
+                400,
+                description=debug_error_message(
+                    "pymongo.errors.WriteError: %s" % e
                 ),
             )
         except pymongo.errors.OperationFailure as e:


### PR DESCRIPTION
Closes follow up of #1256 

Additional fix for #1255
This time even if ``json_sort_keys'' is set to True, the key-value pairs in DBRef will keep their order.