### PR TITLE
Add field `normalize_document_for_patch` to control whether apply normalize for validator of patch request.

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -776,6 +776,11 @@ uppercase.
                                     note that with the default Mongo layer,
                                     setting this to ``False`` will result in an
                                     error. Defaults to ``True``.
+``NORMALIZE_DOCUMENT_FOR_PATCH``    If ``True``, the patch document will be
+                                    normalized according to schema. This means
+                                    if a field is not included in the patch
+                                    body, it will be reset to the default value
+                                    in its schema.
 
 =================================== =========================================
 
@@ -1120,6 +1125,11 @@ always lowercase.
                                 with the default Mongo layer, setting this to
                                 ``False`` will result in an error. Defaults to
                                 ``True``.
+``normalize_document_for_patch``    If ``True``, the patch document will be
+                                    normalized according to schema. This means
+                                    if a field is not included in the patch
+                                    body, it will be reset to the default value
+                                    in its schema.
 
 =============================== ===============================================
 

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -780,7 +780,9 @@ uppercase.
                                     normalized according to schema. This means
                                     if a field is not included in the patch
                                     body, it will be reset to the default value
-                                    in its schema.
+                                    in its schema. If ``False``, the field which
+                                    is not included in the patch body will be
+                                    kept untouched. Defaults to ``True``.
 
 =================================== =========================================
 
@@ -1129,7 +1131,9 @@ always lowercase.
                                     normalized according to schema. This means
                                     if a field is not included in the patch
                                     body, it will be reset to the default value
-                                    in its schema.
+                                    in its schema. If ``False``, the field which
+                                    is not included in the patch body will be
+                                    kept untouched. Defaults to ``True``.
 
 =============================== ===============================================
 

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -2319,6 +2319,37 @@ The stage ``{"$match": { "name": "$name", "time": "$time"}}`` in the pipeline wi
 The request above will ignore ``"count": {"$sum": "$value"}}``. A
 Custom callback functions can be attached to the ``before_aggregation`` and ``after_aggregation`` event hooks. For more information, see :ref:`aggregation_hooks`.
 
+# Special Note on PATCH
+~~~~~~~~~~~
+``PATCH`` **cannot** remove a field but only update value of the field.
+
+Consider the following schema:
+
+```
+'entity': {
+  'name': {
+    'type': 'string',
+    'required': True },
+  'contact': {
+    'type': 'dict',
+    'required': True,
+    'schema': {
+      'phone': {
+        'type': 'string',
+        'required': False,
+        'default': '1234567890' },
+      'email': {
+        'type': 'string',
+        'required': False,
+        'default': 'abc@efg.com' },
+    }
+  }
+}
+```
+
+Two notations ``contact: { email: 'an email'}`` and ``contact.email: 'an email'`` can be used to update the `email` field embedded in `contact` field.
+
+
 Limitations
 ~~~~~~~~~~~
 Client pagination (``?page=2``) is enabled by default. This is currently

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -2349,6 +2349,31 @@ Consider the following schema:
 
 Two notations ``contact: { email: 'an email'}`` and ``contact.email: 'an email'`` can be used to update the `email` field embedded in `contact` field.
 
+``PATCH`` incorrectly normalizes default values in sub-documents.
+
+Consider the example above, by default, if you apply PATCH with body
+
+```
+{'contact.email': 'xyz@gmail.com'}
+```
+
+to the document:
+
+```
+{'name': 'test account', 'contact': {'email': '123@yahoo.com', 'phone': '9876543210'}}
+```
+
+The document will be updated as:
+
+```
+{'name': 'test account', 'contact': {'email': 'xyz@gmail.com', 'phone': '1234567890'}}
+```
+
+That is the ``contact.phone`` has been reset to the default value in the schema. To avoid this, you could set `False` to the parameter: ``normalize_document_for_patch`` (or ``NORMALIZE_DOCUMENT_FOR_PATCH`` globally), in which case, the document will be updated as:
+
+```
+{'name': 'test account', 'contact': {'email': '123@yahoo.com', 'phone': '9876543210'}}
+```
 
 Limitations
 ~~~~~~~~~~~

--- a/eve/default_settings.py
+++ b/eve/default_settings.py
@@ -265,3 +265,8 @@ MONGO_QUERY_BLACKLIST = ["$where", "$regex"]
 # aknowledged writes). This is also the current PyMongo/Mongo default setting.
 MONGO_WRITE_CONCERN = {"w": 1}
 MONGO_OPTIONS = {"connect": True, "tz_aware": True}
+
+# if true, the document will be normalized according to the schema during patch
+# this means the fields will be reset to the default value, if not contained in
+# the patch body.
+NORMALIZE_DOCUMENT_FOR_PATCH = True

--- a/eve/flaskapp.py
+++ b/eve/flaskapp.py
@@ -681,6 +681,9 @@ class Eve(Flask, Events):
         settings.setdefault(
             "normalize_dotted_fields", self.config["NORMALIZE_DOTTED_FIELDS"]
         )
+        settings.setdefault(
+            "normalize_document_for_patch", self.config["NORMALIZE_DOCUMENT_FOR_PATCH"]
+        )
         # empty schemas are allowed for read-only access to resources
         schema = settings.setdefault("schema", {})
         self.set_schema_defaults(schema, settings["id_field"])

--- a/eve/methods/patch.py
+++ b/eve/methods/patch.py
@@ -152,6 +152,7 @@ def patch_internal(
 
     resource_def = app.config["DOMAIN"][resource]
     schema = resource_def["schema"]
+    normalize_document = resource_def.get("normalize_document_for_patch")
     validator = app.validator(
         schema, resource=resource, allow_unknown=resource_def["allow_unknown"]
     )
@@ -174,7 +175,9 @@ def patch_internal(
         if skip_validation:
             validation = True
         else:
-            validation = validator.validate_update(updates, object_id, original)
+            validation = validator.validate_update(
+                updates, object_id, original, normalize_document
+            )
             updates = validator.document
 
         if validation:

--- a/eve/tests/test_settings.py
+++ b/eve/tests/test_settings.py
@@ -246,6 +246,7 @@ products = {
 
 test_patch = {
     "datasource": {"source": "test_patch"},
+    "normalize_document_for_patch": False,
     "schema": {
         "name": {"type": "string", "required": True},
         "contact": {

--- a/eve/validation.py
+++ b/eve/validation.py
@@ -27,17 +27,22 @@ class Validator(cerberus.Validator):
 
         super(Validator, self).__init__(*args, **kwargs)
 
-    def validate_update(self, document, document_id, persisted_document=None):
+    def validate_update(
+        self, document, document_id, persisted_document=None, normalize_document=True
+    ):
         """ Validate method to be invoked when performing an update, not an
         insert.
 
         :param document: the document to be validated.
         :param document_id: the unique id of the document.
         :param persisted_document: the persisted document to be updated.
+        :param normalize_document: whether apply normalization during patch.
         """
         self.document_id = document_id
         self.persisted_document = persisted_document
-        return super(Validator, self).validate(document, update=True)
+        return super(Validator, self).validate(
+            document, update=True, normalize=normalize_document
+        )
 
     def validate_replace(self, document, document_id, persisted_document=None):
         """ Validation method to be invoked when performing a document


### PR DESCRIPTION
By default it is true, in this case the fields which are not included in the patch body will be reset to the default value specified in the schema.

@nicolaiarocci sorry for multiple requests for a single issue. My previous request will break existing tests and this requests pass test in my repository.

#1234