### PR TITLE
Fix documents being mutated while computing etag with ignore_fields settings

### DIFF
--- a/eve/tests/utils.py
+++ b/eve/tests/utils.py
@@ -169,6 +169,7 @@ class TestUtils(TestBase):
 
     def test_document_etag_ignore_fields(self):
         test = {"key1": "value1", "key2": "value2"}
+        test_copy = copy.deepcopy(test)
         ignore_fields = ["key2"]
         test_without_ignore = {"key1": "value1"}
         challenge = dumps(test_without_ignore, sort_keys=True).encode("utf-8")
@@ -176,6 +177,7 @@ class TestUtils(TestBase):
             self.assertEqual(
                 hashlib.sha1(challenge).hexdigest(), document_etag(test, ignore_fields)
             )
+            self.assertEqual(test, test_copy)
 
         # not required fields can not be present
         test = {"key1": "value1", "key2": "value2"}
@@ -189,6 +191,7 @@ class TestUtils(TestBase):
 
         # ignore fiels nested using doting notation
         test = {"key1": "value1", "dict": {"key2": "value2", "key3": "value3"}}
+        test_copy = copy.deepcopy(test)
         ignore_fields = ["dict.key2"]
         test_without_ignore = {"key1": "value1", "dict": {"key3": "value3"}}
         challenge = dumps(test_without_ignore, sort_keys=True).encode("utf-8")
@@ -196,6 +199,7 @@ class TestUtils(TestBase):
             self.assertEqual(
                 hashlib.sha1(challenge).hexdigest(), document_etag(test, ignore_fields)
             )
+            self.assertEqual(test, test_copy)
 
         # ignore fiels nested using doting notation when a root part of the field is not present
         test = {"key1": "value1", "dict": {"key2": "value2"}}

--- a/eve/utils.py
+++ b/eve/utils.py
@@ -16,7 +16,7 @@ from importlib import import_module
 import eve
 import hashlib
 import werkzeug.exceptions
-from copy import copy
+from copy import deepcopy
 from flask import request
 from flask import current_app as app
 from datetime import datetime, timedelta
@@ -352,7 +352,7 @@ def document_etag(value, ignore_fields=None):
                     # not required fields can be not present
                     pass
 
-        value_ = copy(value)
+        value_ = deepcopy(value)
         filter_ignore_fields(value_, ignore_fields)
     else:
         value_ = value


### PR DESCRIPTION
As copy was used instead of deepcopy, if the ignore_fields setting contains a field that's nested inside others, the function mutated the original while discarding fields to compute the etag as asked.