### PR TITLE
Fix HEADER_TOTAL_COUNT on emtpy resources

### DIFF
--- a/eve/methods/get.py
+++ b/eve/methods/get.py
@@ -281,7 +281,7 @@ def _perform_find(resource, lookup):
 
     response[config.ITEMS] = documents
 
-    if count:
+    if count is not None:
         headers.append((config.HEADER_TOTAL_COUNT, count))
 
     if config.DOMAIN[resource]["hateoas"]:

--- a/eve/tests/methods/get.py
+++ b/eve/tests/methods/get.py
@@ -169,6 +169,17 @@ class TestGet(TestBase):
         total_count = r.headers[self.app.config["HEADER_TOTAL_COUNT"]]
         self.assertEqual(int(total_count), self.known_resource_count)
 
+    def test_get_total_count_header_on_empty_resource(self):
+        url = self.domain[self.empty_resource]["url"]
+        r = self.test_client.head(url)
+        response, status = self.parse_response(r)
+        self.assert200(status)
+        self.assertEqual(response, None)
+
+        self.assertIn(self.app.config["HEADER_TOTAL_COUNT"], r.headers)
+        total_count = r.headers[self.app.config["HEADER_TOTAL_COUNT"]]
+        self.assertEqual(int(total_count), 0)
+
     def test_get_where_mongo_syntax(self):
         where = '{"ref": "%s"}' % self.item_name
         response, status = self.get(self.known_resource, "?where=%s" % where)


### PR DESCRIPTION
the count returned by `app.find` might be None if the count is disabled.
Later in get_internal, the HEADER_TOTAL_COUNT is prepared if the count
is enabled.

This commit fixes a bug that filtered out the HEADER_TOTAL_COUNT when
the resource is empty and the count is 0 because the check is done with a truthy condition. This truthy
condition has been replaced by an explicit `is not None` condition.

Fixes #1279 