### PR TITLE
Fixes behaviour of PUT requests not setting default values of fields.

### DIFF
--- a/eve/tests/__init__.py
+++ b/eve/tests/__init__.py
@@ -495,6 +495,7 @@ class TestBase(TestMinimal):
                 "ref": self.random_string(schema["ref"]["maxlength"]),
                 "prog": i,
                 "role": random.choice(schema["role"]["allowed"]),
+                "title": schema["title"]["default"],
                 "rows": self.random_rows(random.randint(0, 5)),
                 "alist": self.random_list(random.randint(0, 5)),
                 "location": {
@@ -504,6 +505,10 @@ class TestBase(TestMinimal):
                 "born": datetime.today() + timedelta(days=random.randint(-10, 10)),
                 "tid": ObjectId(),
                 "read_only_field": schema["read_only_field"]["default"],
+                "dependency_field1": schema["dependency_field1"]["default"],
+                # The schema for contacts has a field named 'unsetted_default_value_field'
+                # That is not initialized here on purpose. See put test on
+                # tests.put.put_default_value_when_field_missing
             }
             if standard_date_fields:
                 contact[eve.LAST_UPDATED] = dt

--- a/eve/tests/methods/post.py
+++ b/eve/tests/methods/post.py
@@ -145,8 +145,10 @@ class TestPost(TestBase):
         self.assertPostItem(data, test_field, test_value)
 
     def test_post_default_value(self):
-        test_field = "title"
-        test_value = "Mr."
+        test_field = "unsetted_default_value_field"
+        test_value = self.domain["contacts"]["schema"]["unsetted_default_value_field"][
+            "default"
+        ]
         data = {"ref": "9234567890123456789054321"}
         self.assertPostItem(data, test_field, test_value)
 
@@ -767,6 +769,24 @@ class TestPost(TestBase):
         data = {test_field: test_value}
         r, status = self.post(self.known_resource_url, data=data)
         self.assertValidationErrorStatus(status)
+
+    def test_post_with_nested_default(self):
+        """ Test that in post of a field that has nested fields with default values
+            those default values are set
+        """
+        del self.domain["contacts"]["schema"]["ref"]["required"]
+        test_field = "dict_with_nested_default"
+        test_value = {}
+        data = {test_field: test_value}
+        r, status = self.post(self.known_resource_url, data=data)
+        self.assert201(status)
+
+        item_id = r[self.domain[self.known_resource]["id_field"]]
+        raw_r = self.test_client.get("%s/%s" % (self.known_resource_url, item_id))
+        item, status = self.parse_response(raw_r)
+        self.assertEqual(
+            item["dict_with_nested_default"], {"nested_field_with_default": "nested"}
+        )
 
     def test_post_readonly_in_dict(self):
         # Test that a post with a readonly field inside a dict is properly

--- a/eve/tests/test_settings.py
+++ b/eve/tests/test_settings.py
@@ -85,6 +85,12 @@ contacts = {
             "type": "string",
             "dependencies": {"dependency_field1": "value"},
         },
+        "dependency_field4": {"type": "string"},
+        "dependency_field5": {"type": "string", "dependencies": ["dependency_field4"]},
+        "dependency_field6": {
+            "type": "string",
+            "dependencies": {"dependency_field4": "value"},
+        },
         "read_only_field": {"type": "string", "default": "default", "readonly": True},
         "dict_with_read_only": {
             "type": "dict",
@@ -94,6 +100,13 @@ contacts = {
                     "default": "default",
                     "readonly": True,
                 }
+            },
+        },
+        "dict_with_nested_default": {
+            "type": "dict",
+            "schema": {
+                "nested_field": {"type": "string"},
+                "nested_field_with_default": {"type": "string", "default": "nested"},
             },
         },
         "key1": {"type": "string"},
@@ -112,6 +125,7 @@ contacts = {
                 "schema": {"challenge": {"type": "objectid"}},
             },
         },
+        "unsetted_default_value_field": {"type": "string", "default": "value"},
     },
 }
 

--- a/eve/tests/versioning.py
+++ b/eve/tests/versioning.py
@@ -32,6 +32,7 @@ class TestVersioningBase(TestBase):
     def enableVersioning(self, partial=False):
         del self.domain["contacts"]["schema"]["title"]["default"]
         del self.domain["contacts"]["schema"]["dependency_field1"]["default"]
+        del self.domain["contacts"]["schema"]["unsetted_default_value_field"]["default"]
         del self.domain["contacts"]["schema"]["read_only_field"]["default"]
         del self.domain["contacts"]["schema"]["dict_with_read_only"]["schema"][
             "read_only_in_dict"


### PR DESCRIPTION
* Refactor of "contacts" test data so it honours the fields that should have defaults when created
* Added a new fields in "contacts" schema to be able to properly refactor tests related to default values
* Added tests to cover several scenarios where default values are involved