### PR TITLE
Add "unique_within_resource" validation rule

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -1293,6 +1293,17 @@ defining the field validation rules. Allowed validation rules are:
                                 If URRA is not active on the endpoint, this
                                 rule behaves like ``unique``
 
+``unique_within_resource``      The value of the field must be unique within
+                                the resource.
+
+                                This differs from the ``unique`` rule in that
+                                it will use the datasource filter when searching
+                                for documents with the same value for the field.
+                                Use this when the resource shares the database
+                                collection with other resources but their documents
+                                should not be taken into account when evaluating
+                                the uniqueness of the field.
+
 ``data_relation``               Allows to specify a referential integrity rule
                                 that the value must satisfy in order to
                                 validate. It is a dict with four keys:

--- a/eve/io/mongo/validation.py
+++ b/eve/io/mongo/validation.py
@@ -74,6 +74,11 @@ class Validator(Validator):
 
         self._is_value_unique(unique, field, value, query)
 
+    def _validate_unique_within_resource(self, unique, field, value):
+        """ {'type': 'boolean'} """
+        _, filter_, _, _ = app.data.datasource(self.resource)
+        self._is_value_unique(unique, field, value, filter_)
+
     def _validate_unique(self, unique, field, value):
         """ {'type': 'boolean'} """
         self._is_value_unique(unique, field, value, {})

--- a/eve/tests/methods/post.py
+++ b/eve/tests/methods/post.py
@@ -975,6 +975,12 @@ class TestPost(TestBase):
         self.assertTrue("ref" in r)
         self.assertTrue("aninteger" not in r)
 
+    def test_unique_value_different_resources(self):
+        r, status = self.post("tenant_a", data={"name": "John"})
+        self.assert201(status)
+        r, status = self.post("tenant_b", data={"name": "John"})
+        self.assert201(status)
+
     def perform_post(self, data, valid_items=[0]):
         r, status = self.post(self.known_resource_url, data=data)
         self.assert201(status)

--- a/eve/tests/test_settings.py
+++ b/eve/tests/test_settings.py
@@ -282,6 +282,22 @@ test_patch = {
     },
 }
 
+tenant_a = {
+    "datasource": {"source": "tenants", "filter": {"_tenant": "tenant_a"}},
+    "schema": {
+        "_tenant": {"type": "string", "readonly": True, "default": "tenant_a"},
+        "name": {"type": "string", "required": True, "unique_within_resource": True},
+    },
+}
+
+tenant_b = {
+    "datasource": {"source": "tenants", "filter": {"_tenant": "tenant_b"}},
+    "schema": {
+        "_tenant": {"type": "string", "readonly": True, "default": "tenant_b"},
+        "name": {"type": "string", "required": True, "unique_within_resource": True},
+    },
+}
+
 child_products = copy.deepcopy(products)
 child_products["url"] = 'products/<regex("[A-Z]+"):parent_product>/children'
 child_products["datasource"] = {"source": "products"}
@@ -316,4 +332,6 @@ DOMAIN = {
     "child_products": child_products,
     "exclusion": exclusion,
     "test_patch": test_patch,
+    "tenant_a": tenant_a,
+    "tenant_b": tenant_b,
 }


### PR DESCRIPTION
Add new validation rule `unique_within_resource`.

This new validation rule enforces the uniqueness of an attribute only at API resource level, contrasting with the `unique` rule that enforces uniqueness at database collection level.

Fixes #1291 