### PR TITLE
Update README funding URL

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -99,4 +99,4 @@ distributed under the `BSD license
 <https://github.com/pyeve/eve/blob/master/LICENSE>`_.
 
 .. _`Nicola Iarocci`: http://nicolaiarocci.com
-.. _`funding page`: http://python-eve.org/funding
+.. _`funding page`: http://python-eve.org/funding.html


### PR DESCRIPTION
Minor update to the README, just noticed while browsing.

Current URL (http://python-eve.org/funding):
![image](https://user-images.githubusercontent.com/1350214/68515198-17e7e700-024e-11ea-947c-6b621fa8b75e.png)

Updated URL (http://python-eve.org/funding.html):
![image](https://user-images.githubusercontent.com/1350214/68515236-36e67900-024e-11ea-90be-a9ca8aaf1984.png)

