### PR TITLE
Always coerce id fields when performing mongotize even if query_objectid_as_string is on.

### DIFF
--- a/eve/io/mongo/mongo.py
+++ b/eve/io/mongo/mongo.py
@@ -784,7 +784,7 @@ class Mongo(DataLayer):
                 ),
             )
 
-    def _mongotize(self, source, resource):
+    def _mongotize(self, source, resource, parse_objectid=False):
         """ Recursively iterates a JSON dictionary, turning RFC-1123 strings
         into datetime values and ObjectId-link strings into ObjectIds.
 
@@ -808,7 +808,8 @@ class Mongo(DataLayer):
         schema = resource_def.get("schema")
         id_field = resource_def["id_field"]
         id_field_versioned = versioned_id_field(resource_def)
-        parse_objectid = not resource_def.get("query_objectid_as_string", False)
+        query_objectid_as_string = resource_def.get("query_objectid_as_string", False)
+        parse_objectid = parse_objectid or not query_objectid_as_string
 
         def try_cast(k, v, should_parse_objectid):
             try:
@@ -868,7 +869,7 @@ class Mongo(DataLayer):
             schema_type = get_schema_type(keys, schema)
             is_objectid = (schema_type == "objectid") or parse_objectid
             if isinstance(v, dict):
-                self._mongotize(v, resource)
+                self._mongotize(v, resource, is_objectid)
             elif isinstance(v, list):
                 for i, v1 in enumerate(v):
                     if isinstance(v1, dict):

--- a/eve/io/mongo/mongo.py
+++ b/eve/io/mongo/mongo.py
@@ -867,13 +867,13 @@ class Mongo(DataLayer):
 
         for k, v in source.items():
             if isinstance(v, dict):
-                self._mongotize(v, resource, parse_objectid) # was False
+                self._mongotize(v, resource, not skip_objectid)
             elif isinstance(v, list):
                 for i, v1 in enumerate(v):
                     if isinstance(v1, dict):
-                        source[k][i] = self._mongotize(v1, resource, parse_objectid) # was False
+                        source[k][i] = self._mongotize(v1, resource, not skip_objectid)
                     else:
-                        source[k][i] = try_cast(k, v1, parse_objectid)
+                        source[k][i] = try_cast(k, v1, not skip_objectid)
             elif isinstance(v, str_type):
                 source[k] = try_cast(k, v, parse_objectid)
 

--- a/eve/tests/__init__.py
+++ b/eve/tests/__init__.py
@@ -499,7 +499,7 @@ class TestBase(TestMinimal):
                 "prog": i,
                 "role": random.choice(schema["role"]["allowed"]),
                 "title": schema["title"]["default"],
-                "rows": self.random_rows(random.randint(0, 5)),
+                "rows": self.random_rows(random.randint(1, 5)),
                 "alist": self.random_list(random.randint(0, 5)),
                 "location": {
                     "address": "address " + self.random_string(5),

--- a/eve/tests/__init__.py
+++ b/eve/tests/__init__.py
@@ -433,6 +433,7 @@ class TestBase(TestMinimal):
         self.item_tid = contact["tid"]
         self.item_etag = contact[ETAG]
         self.item_ref = contact["ref"]
+        self.item_rows = contact["rows"]
         self.item_id_url = "/%s/%s" % (
             self.domain[self.known_resource]["url"],
             self.item_id,
@@ -519,6 +520,9 @@ class TestBase(TestMinimal):
             contacts.append(contact)
         return contacts
 
+    def to_list_string(self, list_of_strings):
+        return '["%s"]' % '","'.join(list_of_strings)
+
     def random_users(self, num):
         users = self.random_contacts(num)
         for user in users:
@@ -569,6 +573,9 @@ class TestBase(TestMinimal):
     def random_string(self, num):
         return "".join(random.choice(string.ascii_uppercase) for x in range(num))
 
+    def random_hexstring(self, num):
+        return "".join(random.choice(string.hexdigits).lower() for x in range(num))
+
     def random_list(self, num):
         alist = []
         for i in range(num):
@@ -581,7 +588,7 @@ class TestBase(TestMinimal):
         for _ in range(num):
             rows.append(
                 {
-                    "sku": self.random_string(schema["sku"]["maxlength"]),
+                    "sku": self.random_hexstring(schema["sku"]["maxlength"]),
                     "price": random.randint(100, 1000),
                 }
             )

--- a/eve/tests/methods/get.py
+++ b/eve/tests/methods/get.py
@@ -240,6 +240,19 @@ class TestGet(TestBase):
         resource = response["_items"]
         self.assertEqual(len(resource), 0)
 
+    def test_get_where_mongo_objectid_as_string_but_field_is_id(self):
+        where_in = '{"tid": { "$in": ["%s"]} }' % self.item_tid
+        response, status = self.get(self.known_resource, "?where=%s" % where_in)
+        self.assert200(status)
+        resource = response["_items"]
+        self.assertEqual(len(resource), 1)
+
+        self.app.config["DOMAIN"]["contacts"]["query_objectid_as_string"] = True
+        response, status = self.get(self.known_resource, "?where=%s" % where_in)
+        self.assert200(status)
+        resource = response["_items"]
+        self.assertEqual(len(resource), 0)
+
     def test_get_where_python_syntax(self):
         where = "ref == %s" % self.item_name
         response, status = self.get(self.known_resource, "?where=%s" % where)

--- a/eve/tests/methods/get.py
+++ b/eve/tests/methods/get.py
@@ -241,17 +241,18 @@ class TestGet(TestBase):
         self.assertEqual(len(resource), 0)
 
     def test_get_where_mongo_objectid_as_string_but_field_is_id(self):
-        where_in = '{"tid": { "$in": ["%s"]} }' % self.item_tid
+        skus = [item["sku"] for item in self.item_rows]
+        where_in = '{"rows.sku": { "$in": %s} }' % self.to_list_string(skus)
         response, status = self.get(self.known_resource, "?where=%s" % where_in)
         self.assert200(status)
         resource = response["_items"]
-        self.assertEqual(len(resource), 1)
+        self.assertEqual(len(resource), 0)
 
         self.app.config["DOMAIN"]["contacts"]["query_objectid_as_string"] = True
         response, status = self.get(self.known_resource, "?where=%s" % where_in)
         self.assert200(status)
         resource = response["_items"]
-        self.assertEqual(len(resource), 0)
+        self.assertEqual(len(resource), 1)
 
     def test_get_where_python_syntax(self):
         where = "ref == %s" % self.item_name

--- a/eve/tests/methods/get.py
+++ b/eve/tests/methods/get.py
@@ -238,11 +238,11 @@ class TestGet(TestBase):
         response, status = self.get(self.known_resource, "?where=%s" % where)
         self.assert200(status)
         resource = response["_items"]
-        self.assertEqual(len(resource), 0)
+        self.assertEqual(len(resource), 1)
 
     def test_get_where_mongo_objectid_as_string_but_field_is_id(self):
         skus = self.to_list_string([item["sku"] for item in self.item_rows])
-        where_in = '{"_id": "%s", "rows.sku": { "$in": %s} }' % (self.item_id, skus)
+        where_in = '{"tid": "%s", "rows.sku": { "$in": %s} }' % (self.item_tid, skus)
         response, status = self.get(self.known_resource, "?where=%s" % where_in)
         self.assert200(status)
         resource = response["_items"]
@@ -253,6 +253,7 @@ class TestGet(TestBase):
         self.assert200(status)
         resource = response["_items"]
         self.assertEqual(len(resource), 1)
+
 
     def test_get_where_python_syntax(self):
         where = "ref == %s" % self.item_name
@@ -1293,11 +1294,12 @@ class TestGet(TestBase):
         # of string type and which value is castable to a ObjectId is still
         # treated as a string when 'query_objectid_as_string' is set to True.
         # See PR #552.
-        data = {"id": "507c7f79bcf86cd7994f6c0e", "name": "john"}
+        self.app.config["DOMAIN"]["contacts"]["query_objectid_as_string"] = True
+        data = {"id": "507c7f79bcf86cd7994f6c0e", "name": "507c7f79bcf86cd7994f6c0e"}
         response, status = self.post("ids", data=data)
         self.assert201(status)
 
-        where = '?where={"id": "507c7f79bcf86cd7994f6c0e"}'
+        where = '?where={"name": "507c7f79bcf86cd7994f6c0e"}'
         response, status = self.get("ids", where)
         self.assert200(status)
         items = response["_items"]

--- a/eve/tests/methods/get.py
+++ b/eve/tests/methods/get.py
@@ -254,7 +254,6 @@ class TestGet(TestBase):
         resource = response["_items"]
         self.assertEqual(len(resource), 1)
 
-
     def test_get_where_python_syntax(self):
         where = "ref == %s" % self.item_name
         response, status = self.get(self.known_resource, "?where=%s" % where)

--- a/eve/tests/methods/get.py
+++ b/eve/tests/methods/get.py
@@ -241,8 +241,8 @@ class TestGet(TestBase):
         self.assertEqual(len(resource), 0)
 
     def test_get_where_mongo_objectid_as_string_but_field_is_id(self):
-        skus = [item["sku"] for item in self.item_rows]
-        where_in = '{"rows.sku": { "$in": %s} }' % self.to_list_string(skus)
+        skus = self.to_list_string([item["sku"] for item in self.item_rows])
+        where_in = '{"_id": "%s", "rows.sku": { "$in": %s} }' % (self.item_id, skus)
         response, status = self.get(self.known_resource, "?where=%s" % where_in)
         self.assert200(status)
         resource = response["_items"]

--- a/eve/tests/methods/get.py
+++ b/eve/tests/methods/get.py
@@ -240,6 +240,19 @@ class TestGet(TestBase):
         resource = response["_items"]
         self.assertEqual(len(resource), 1)
 
+    def test_get_where_mongo_objectid_as_string_with_nested_documents(self):
+        where = '{"tid": { "$in": ["%s"]}}' % self.item_tid
+        response, status = self.get(self.known_resource, "?where=%s" % where)
+        self.assert200(status)
+        resource = response["_items"]
+        self.assertEqual(len(resource), 1)
+
+        self.app.config["DOMAIN"]["contacts"]["query_objectid_as_string"] = True
+        response, status = self.get(self.known_resource, "?where=%s" % where)
+        self.assert200(status)
+        resource = response["_items"]
+        self.assertEqual(len(resource), 1)
+
     def test_get_where_mongo_objectid_as_string_but_field_is_id(self):
         skus = self.to_list_string([item["sku"] for item in self.item_rows])
         where_in = '{"tid": "%s", "rows.sku": { "$in": %s} }' % (self.item_tid, skus)

--- a/eve/tests/test_settings.py
+++ b/eve/tests/test_settings.py
@@ -50,7 +50,7 @@ contacts = {
             "schema": {
                 "type": "dict",
                 "schema": {
-                    "sku": {"type": "string", "maxlength": 10},
+                    "sku": {"type": "string", "maxlength": 24},
                     "price": {"type": "integer"},
                 },
             },


### PR DESCRIPTION
Addresses #1345 

The Test Widget manufacturer now uses Mongo, so the SKUs resemble ObjectIds. Added a failing test to show why this is a problem. Fix the problem.