### PR TITLE
Fix link to extensions on documentation homepage.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -127,4 +127,4 @@ is also a simple `client app`_ available.
 .. _Redis: http://redis.io
 .. _Cerberus: http://python-cerberus.org
 .. _events: https://github.com/pyeve/events
-.. _extensions: http://python-eve.org/extensions
+.. _extensions: http://python-eve.org/extensions.html


### PR DESCRIPTION
RTD needs a suffix, `extensions` -> `extensions.html`.