### PR TITLE
Add coverage report to track what has been tested and what hasn't.

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,13 @@
+codecov:
+  notify:
+    require_ci_to_pass: no
+    after_n_builds: 1
+coverage:
+  status:
+    project:
+      default:
+        # Require 1% coverage, i.e., always succeed
+        target: 1
+    patch: false
+    changes: false
+comment: off

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[report]
+omit=
+  eve/test

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,3 +26,8 @@ matrix:
       python: "3.8"
     - env: TOXENV=pypy3
       python: "pypy3.5-6.0"
+    - env: TOXENV=coverage
+      python: "3.7"
+      script:
+        - tox --recreate
+        - bash <(curl -s https://codecov.io/bash)

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ INSTALL_REQUIRES = [
 
 EXTRAS_REQUIRE = {
     "docs": ["sphinx", "alabaster", "doc8"],
-    "tests": ["redis", "testfixtures", "pytest", "tox"],
+    "tests": ["redis", "testfixtures", "pytest", "tox", "pytest-cov", "coveralls"],
 }
 EXTRAS_REQUIRE["dev"] = EXTRAS_REQUIRE["tests"] + EXTRAS_REQUIRE["docs"]
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
-envlist=py27,py35,py36,py37,py38,pypy3,linting
+envlist=py27,py35,py36,py37,py38,pypy3,linting,coverage
 
 [testenv]
 extras=tests
-commands=py.test eve {posargs}
+commands=py.test {posargs}
 
 [testenv:linting]
 skipsdist = True
@@ -11,6 +11,10 @@ usedevelop = True
 basepython = python3.7
 deps = pre-commit
 commands = pre-commit run --all-files
+
+[testenv:coverage]
+basepython = python3.7
+commands = py.test --cov --cov-report=xml {posargs}
 
 [flake8]
 max-line-length = 88


### PR DESCRIPTION
@nicolaiarocci to take advantage of this you will have to make an account on https://codecov.io/ which links to this github repo.

You will also need to set the CODECOV_TOKEN envvar in your travis build settings. This is a secret token so you need to do it in the web interface instead of adding it to the .travis.yml.

An example report is here: https://codecov.io/gh/ehiggs/eve/branch/add-coverage-report