### PR TITLE
Add 403 Forbidden to STANDARD_ERRORS

### DIFF
--- a/eve/default_settings.py
+++ b/eve/default_settings.py
@@ -131,7 +131,7 @@ VALIDATION_ERROR_AS_LIST = False
 
 # codes for which we want to return a standard response which includes
 # a JSON body with the status, code, and description.
-STANDARD_ERRORS = [400, 401, 404, 405, 406, 409, 410, 412, 422, 428, 429]
+STANDARD_ERRORS = [400, 401, 403, 404, 405, 406, 409, 410, 412, 422, 428, 429]
 
 # field returned on GET requests so we know if we have the latest copy even if
 # we access a specific version

--- a/eve/tests/config.py
+++ b/eve/tests/config.py
@@ -85,7 +85,7 @@ class TestConfig(TestBase):
         self.assertEqual(self.app.config["SHOW_DELETED_PARAM"], "show_deleted")
         self.assertEqual(
             self.app.config["STANDARD_ERRORS"],
-            [400, 401, 404, 405, 406, 409, 410, 412, 422, 428, 429],
+            [400, 401, 403, 404, 405, 406, 409, 410, 412, 422, 428, 429],
         )
         self.assertEqual(self.app.config["UPSERT_ON_PUT"], True)
         self.assertEqual(


### PR DESCRIPTION
This isn't actually an error the Eve Framework will ever raise. As far
as I could tell.

However, separation between authentication and authorization is a must
even for less complex applicatons. 403 is the most adequate response a
server can provide to client whose authentication was accepted, yet for
some reason or another the server will not comply with the request.

The Eve Framework documentation suggests the usage of 403 in, at least
two instances:

 * `abort(403)` in: https://docs.python-eve.org/en/stable/features.html#database-event-hooks
 * The actual documentation for the `STANDARD_ERRORS` config variable,
describes 403 as a supported code, in: https://docs.python-eve.org/en/stable/config.html#global-configuration