### PR TITLE
Fix for #1364

### DIFF
--- a/eve/io/mongo/validation.py
+++ b/eve/io/mongo/validation.py
@@ -92,7 +92,11 @@ class Validator(Validator):
         .. versionadded:: 0.6
         """
         if unique:
-            query[field] = value
+            attribute_path = list(self.document_path + (field,))
+            temp_path = [x for x in attribute_path if not isinstance(x, int)]
+            final_path = ".".join(temp_path)
+
+            query[final_path] = value
 
             resource_config = config.DOMAIN[self.resource]
 

--- a/eve/tests/__init__.py
+++ b/eve/tests/__init__.py
@@ -177,6 +177,9 @@ class TestMinimal(unittest.TestCase):
                 self.assertTrue(k in issues)
                 if isinstance(v, dict):
                     assert_errors(issues[k], matches[k])
+                elif isinstance(v, list):
+                    for i in v:
+                        self.assertTrue(i in issues[k])
                 else:
                     self.assertTrue(v in issues[k])
 

--- a/eve/tests/__init__.py
+++ b/eve/tests/__init__.py
@@ -448,7 +448,8 @@ class TestBase(TestMinimal):
             self.domain[self.known_resource]["url"],
             self.item_name,
         )
-        self.alt_ref = self.response_item(response, 1)["ref"]
+        self.alt_item = self.response_item(response, 1)
+        self.alt_ref = self.alt_item["ref"]
 
         response, _ = self.get("payments", "?max_results=1")
         self.readonly_id = self.response_item(response)["_id"]
@@ -515,6 +516,12 @@ class TestBase(TestMinimal):
                 "tid": ObjectId(),
                 "read_only_field": schema["read_only_field"]["default"],
                 "dependency_field1": schema["dependency_field1"]["default"],
+                "unique_elements_list": [
+                    {
+                        "first_nested_field": self.random_string(10),
+                        "second_nested_field": self.random_string(10),
+                    }
+                ],
                 # The schema for contacts has a field named 'unsetted_default_value_field'
                 # That is not initialized here on purpose. See put test on
                 # tests.put.put_default_value_when_field_missing

--- a/eve/tests/__init__.py
+++ b/eve/tests/__init__.py
@@ -172,9 +172,15 @@ class TestMinimal(unittest.TestCase):
         issues = response[ISSUES]
         self.assertTrue(len(issues))
 
-        for k, v in matches.items():
-            self.assertTrue(k in issues)
-            self.assertTrue(v in issues[k])
+        def assert_errors(issues, matches):
+            for k, v in matches.items():
+                self.assertTrue(k in issues)
+                if isinstance(v, dict):
+                    assert_errors(issues[k], matches[k])
+                else:
+                    self.assertTrue(v in issues[k])
+
+        assert_errors(issues, matches)
 
     def assertExpires(self, resource):
         # TODO if we ever get access to response.date (it is None), compare

--- a/eve/tests/methods/patch.py
+++ b/eve/tests/methods/patch.py
@@ -136,6 +136,18 @@ class TestPatch(TestBase):
             r, {"ref": "value '%s' is not unique" % self.alt_ref}
         )
 
+    def test_nested_unique_value(self):
+        field = "unique_elements_list"
+        data = {
+            field: self.alt_item[field],
+        }
+        r, status = self.put(
+            self.item_id_url, data=data, headers=[("If-Match", self.item_etag)],
+        )
+        self.assert422(status)
+        expected = {"0": "value '%s' is not unique" % self.alt_item[field][0]}
+        self.assertValidationError(r, {field: expected})
+
     def test_patch_string(self):
         field = "ref"
         test_value = "1234567890123456789012345"

--- a/eve/tests/methods/post.py
+++ b/eve/tests/methods/post.py
@@ -868,6 +868,17 @@ class TestPost(TestBase):
         self.assertEqual(values["city"], "a nested city")
         self.assertEqual(values["address"], "a nested address")
 
+    def test_post_nested_unique(self):
+        del self.domain["contacts"]["schema"]["ref"]["required"]
+        field = "unique_elements_list"
+        data = {
+            field: self.alt_item[field],
+        }
+        r, status = self.post(self.known_resource_url, data=data)
+        self.assert422(status)
+        expected = {"0": "value '%s' is not unique" % self.alt_item[field][0]}
+        self.assertValidationError(r, {field: expected})
+
     def test_post_error_as_list(self):
         del self.domain["contacts"]["schema"]["ref"]["required"]
         self.app.config["VALIDATION_ERROR_AS_LIST"] = True

--- a/eve/tests/methods/put.py
+++ b/eve/tests/methods/put.py
@@ -79,6 +79,19 @@ class TestPut(TestBase):
             r, {"ref": "value '%s' is not unique" % self.alt_ref}
         )
 
+    def test_nested_unique_value(self):
+        field = "unique_elements_list"
+        data = {
+            "ref": self.item["ref"],
+            field: self.alt_item[field],
+        }
+        r, status = self.put(
+            self.item_id_url, data=data, headers=[("If-Match", self.item_etag)],
+        )
+        self.assert422(status)
+        expected = {"0": "value '%s' is not unique" % self.alt_item[field][0]}
+        self.assertValidationError(r, {field: expected})
+
     def test_allow_unknown(self):
         changes = {"unknown": "unknown"}
         r, status = self.put(

--- a/eve/tests/test_settings.py
+++ b/eve/tests/test_settings.py
@@ -126,6 +126,17 @@ contacts = {
             },
         },
         "unsetted_default_value_field": {"type": "string", "default": "value"},
+        "unique_elements_list": {
+            "type": "list",
+            "schema": {
+                "type": "dict",
+                "unique": True,
+                "schema": {
+                    "first_nested_field": {"type": "string"},
+                    "second_nested_field": {"type": "string"},
+                },
+            },
+        },
     },
 }
 

--- a/eve/tests/versioning.py
+++ b/eve/tests/versioning.py
@@ -997,7 +997,7 @@ class TestVersionedDataRelation(TestNormalVersioning):
         r, status = self.post("/invoices/", data=data)
         self.assertValidationErrorStatus(status)
         self.assertValidationError(
-            r, {"person": {value_field: "must be of objectid type"}}
+            r, {"person": [{value_field: "must be of objectid type"}]}
         )
 
         # unknown id


### PR DESCRIPTION
I've improved the code for the `unique` constraints in nested fields. Now it's working on all kind of schemas. I also think that this implementation is more readable than before for future contributors. I've also implemented some tests and added support to assert to nested validation errors in the tests.