### PR TITLE
Fix support for dicts without schema rule

### DIFF
--- a/eve/io/mongo/mongo.py
+++ b/eve/io/mongo/mongo.py
@@ -856,9 +856,7 @@ class Mongo(DataLayer):
                         return next((t for t in possible_types if t), None)
                 elif "schema" in schema[k]:
                     # recursively check the schema
-                    return get_schema_type(
-                        keys, dict_sub_schema(schema[k]["schema"])
-                    )
+                    return get_schema_type(keys, dict_sub_schema(schema[k]["schema"]))
             elif schema_type == "dict":
                 if "schema" in schema[k]:
                     return get_schema_type(keys, dict_sub_schema(schema[k]["schema"]))

--- a/eve/io/mongo/mongo.py
+++ b/eve/io/mongo/mongo.py
@@ -857,10 +857,11 @@ class Mongo(DataLayer):
                 elif "schema" in schema[k]:
                     # recursively check the schema
                     return get_schema_type(
-                        keys, dict_sub_schema(schema[k].get("schema"))
+                        keys, dict_sub_schema(schema[k]["schema"])
                     )
             elif schema_type == "dict":
-                return get_schema_type(keys, dict_sub_schema(schema[k].get("schema")))
+                if "schema" in schema[k]:
+                    return get_schema_type(keys, dict_sub_schema(schema[k]["schema"]))
             else:
                 return schema_type
 


### PR DESCRIPTION
dicts without schema rule are broken since b8d8fcd5a6d2093ec135a021f5b0f48d2c419dfe

The fix is simple, I've just followed the pattern used for the lists. 