### PR TITLE
Fix unique_within_resource rule used in resources without datasource filter

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -1317,7 +1317,7 @@ defining the field validation rules. Allowed validation rules are:
                                 should not be taken into account when evaluating
                                 the uniqueness of the field. When used in a resource
                                 without datasource filter, this rule behaves like
-                                ``unique``. 
+                                ``unique``.
 
 ``data_relation``               Allows to specify a referential integrity rule
                                 that the value must satisfy in order to

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -1315,7 +1315,9 @@ defining the field validation rules. Allowed validation rules are:
                                 Use this when the resource shares the database
                                 collection with other resources but their documents
                                 should not be taken into account when evaluating
-                                the uniqueness of the field.
+                                the uniqueness of the field. When used in a resource
+                                without datasource filter, this rule behaves like
+                                ``unique``. 
 
 ``data_relation``               Allows to specify a referential integrity rule
                                 that the value must satisfy in order to

--- a/eve/io/mongo/validation.py
+++ b/eve/io/mongo/validation.py
@@ -77,6 +77,8 @@ class Validator(Validator):
     def _validate_unique_within_resource(self, unique, field, value):
         """ {'type': 'boolean'} """
         _, filter_, _, _ = app.data.datasource(self.resource)
+        if filter_ is None:
+            filter_ = {}
         self._is_value_unique(unique, field, value, filter_)
 
     def _validate_unique(self, unique, field, value):

--- a/eve/tests/methods/post.py
+++ b/eve/tests/methods/post.py
@@ -975,10 +975,24 @@ class TestPost(TestBase):
         self.assertTrue("ref" in r)
         self.assertTrue("aninteger" not in r)
 
-    def test_unique_value_different_resources(self):
+    def test_unique_within_resource_value_different_resources(self):
         r, status = self.post("tenant_a", data={"name": "John"})
         self.assert201(status)
         r, status = self.post("tenant_b", data={"name": "John"})
+        self.assert201(status)
+
+    def test_unique_within_resource_in_resource_without_filter(self):
+        r, status = self.post(
+            "test_unique", data={"unique_within_resource_attribute": "unique_value"}
+        )
+        self.assert201(status)
+        r, status = self.post(
+            "test_unique", data={"unique_within_resource_attribute": "unique_value"}
+        )
+        self.assert422(status)
+        r, status = self.post(
+            "test_unique", data={"unique_within_resource_attribute": "unique_value 2"}
+        )
         self.assert201(status)
 
     def perform_post(self, data, valid_items=[0]):

--- a/eve/tests/test_settings.py
+++ b/eve/tests/test_settings.py
@@ -298,6 +298,17 @@ tenant_b = {
     },
 }
 
+test_unique = {
+    "datasource": {"source": "test_unique"},
+    "schema": {
+        "unique_attribute": {"type": "string", "unique": True},
+        "unique_within_resource_attribute": {
+            "type": "string",
+            "unique_within_resource": True,
+        },
+    },
+}
+
 child_products = copy.deepcopy(products)
 child_products["url"] = 'products/<regex("[A-Z]+"):parent_product>/children'
 child_products["datasource"] = {"source": "products"}
@@ -334,4 +345,5 @@ DOMAIN = {
     "test_patch": test_patch,
     "tenant_a": tenant_a,
     "tenant_b": tenant_b,
+    "test_unique": test_unique,
 }


### PR DESCRIPTION
#1292 didn't contemplate the use of this new rule on resources that don't need it (but might use it). This PR fixes the issue. 