### PR TITLE
Fix the mongo_options work by passing the options into find_one

### DIFF
--- a/eve/io/base.py
+++ b/eve/io/base.py
@@ -163,6 +163,7 @@ class DataLayer(object):
         req,
         check_auth_value=True,
         force_auth_field_projection=False,
+        mongo_options=None,
         **lookup
     ):
         """Retrieves a single document/record. Consumed when a request hits an
@@ -185,7 +186,8 @@ class DataLayer(object):
                                             include the user-restricted
                                             resource access field (if
                                             configured). Defaults to ``False``.
-
+        :param mongo_options: options to pass to PyMongo. e.g. read_preferences
+                              of the initial get.
         :param **lookup: the lookup fields. This will most likely be a record
                          id or, if alternate lookup is supported by the API,
                          the corresponding query.

--- a/eve/io/mongo/mongo.py
+++ b/eve/io/mongo/mongo.py
@@ -297,12 +297,14 @@ class Mongo(DataLayer):
         req,
         check_auth_value=True,
         force_auth_field_projection=False,
+        mongo_options=None,
         **lookup
     ):
         """Retrieves a single document.
 
         :param resource: resource name.
         :param req: a :class:`ParsedRequest` instance.
+        :param mongo_options: Dict of parameters to pass to PyMongo with_options.
         :param **lookup: lookup query.
 
         .. versionchanged:: 0.6
@@ -345,9 +347,11 @@ class Mongo(DataLayer):
         ):
             filter_ = self.combine_queries(filter_, {config.DELETED: {"$ne": True}})
         # Here, we feed pymongo with `None` if projection is empty.
-        return (
-            self.pymongo(resource).db[datasource].find_one(filter_, projection or None)
-        )
+        target = self.pymongo(resource).db[datasource]
+        if mongo_options:
+            return target.with_options(**mongo_options).find_one(filter_, projection or None)
+        else:
+            return target.find_one(filter_, projection or None)
 
     def find_one_raw(self, resource, **lookup):
         """Retrieves a single raw document.

--- a/eve/io/mongo/mongo.py
+++ b/eve/io/mongo/mongo.py
@@ -349,7 +349,9 @@ class Mongo(DataLayer):
         # Here, we feed pymongo with `None` if projection is empty.
         target = self.pymongo(resource).db[datasource]
         if mongo_options:
-            return target.with_options(**mongo_options).find_one(filter_, projection or None)
+            return target.with_options(**mongo_options).find_one(
+                filter_, projection or None
+            )
         else:
             return target.find_one(filter_, projection or None)
 

--- a/eve/methods/common.py
+++ b/eve/methods/common.py
@@ -61,7 +61,7 @@ def get_document(
                                         the user-restricted resource access
                                         field (if configured). Defaults to
                                         ``False``.
-    :param mongo_options: Options to pass to PyMongo. e.g. ReadConcern
+    :param mongo_options: Options to pass to PyMongo. e.g. read_preferences.
     :param **lookup: document lookup query
 
     .. versionchanged:: 0.6
@@ -87,14 +87,9 @@ def get_document(
     if original:
         document = original
     else:
-        if mongo_options:
-            document = app.data.with_options(mongo_options).find_one(
-                resource, req, check_auth_value, force_auth_field_projection, **lookup
-            )
-        else:
-            document = app.data.find_one(
-                resource, req, check_auth_value, force_auth_field_projection, **lookup
-            )
+        document = app.data.find_one(
+            resource, req, check_auth_value, force_auth_field_projection, mongo_options=mongo_options, **lookup
+        )
 
     if document:
         e_if_m = config.ENFORCE_IF_MATCH

--- a/eve/methods/common.py
+++ b/eve/methods/common.py
@@ -88,7 +88,12 @@ def get_document(
         document = original
     else:
         document = app.data.find_one(
-            resource, req, check_auth_value, force_auth_field_projection, mongo_options=mongo_options, **lookup
+            resource,
+            req,
+            check_auth_value,
+            force_auth_field_projection,
+            mongo_options=mongo_options,
+            **lookup
         )
 
     if document:

--- a/eve/methods/patch.py
+++ b/eve/methods/patch.py
@@ -80,7 +80,7 @@ def patch_internal(
                     option, a request context must be available.
     :param concurrency_check: concurrency check switch (bool)
     :param skip_validation: skip payload validation before write (bool)
-    :param mongo_options: options to pass to PyMongo. e.g. ReadConcern of the initial get.
+    :param mongo_options: options to pass to PyMongo. e.g. read_preferences of the initial get.
     :param **lookup: document lookup query.
 
     .. versionchanged:: 0.6.2
@@ -151,7 +151,7 @@ def patch_internal(
     if payload is None:
         payload = payload_()
 
-    original = get_document(resource, concurrency_check, mongo_options, **lookup)
+    original = get_document(resource, concurrency_check, mongo_options=mongo_options, **lookup)
     if not original:
         # not found
         abort(404)
@@ -219,10 +219,7 @@ def patch_internal(
             if resource_def["merge_nested_documents"]:
                 updates = resolve_nested_documents(updates, updated)
 
-            if mongo_options:
-                updated.with_options(mongo_options).update(updates)
-            else:
-                updated.update(updates)
+            updated.update(updates)
 
             if config.IF_MATCH:
                 resolve_document_etag(updated, resource)

--- a/eve/methods/patch.py
+++ b/eve/methods/patch.py
@@ -151,7 +151,9 @@ def patch_internal(
     if payload is None:
         payload = payload_()
 
-    original = get_document(resource, concurrency_check, mongo_options=mongo_options, **lookup)
+    original = get_document(
+        resource, concurrency_check, mongo_options=mongo_options, **lookup
+    )
     if not original:
         # not found
         abort(404)

--- a/eve/tests/methods/patch.py
+++ b/eve/tests/methods/patch.py
@@ -312,7 +312,7 @@ class TestPatch(TestBase):
         test_field = "ref"
         test_value = "9876543210987654321098765"
         data = {test_field: test_value}
-        mongo_options = {'read_preference': ReadPreference.PRIMARY}
+        mongo_options = {"read_preference": ReadPreference.PRIMARY}
         with self.app.test_request_context(self.item_id_url):
             r, _, _, status = patch_internal(
                 self.known_resource,

--- a/eve/tests/methods/patch.py
+++ b/eve/tests/methods/patch.py
@@ -1,6 +1,8 @@
 import simplejson as json
 
 from bson import ObjectId
+from pymongo import ReadPreference
+
 from eve import ETAG
 from eve import ISSUES
 from eve import LAST_UPDATED
@@ -299,6 +301,24 @@ class TestPatch(TestBase):
                 self.known_resource,
                 data,
                 concurrency_check=False,
+                **{"_id": self.item_id}
+            )
+        db_value = self.compare_patch_with_get(test_field, r)
+        self.assertEqual(db_value, test_value)
+        self.assert200(status)
+
+    def test_patch_internal_with_options(self):
+        # test that patch_internal is available and working properly.
+        test_field = "ref"
+        test_value = "9876543210987654321098765"
+        data = {test_field: test_value}
+        mongo_options = {'read_preference': ReadPreference.PRIMARY}
+        with self.app.test_request_context(self.item_id_url):
+            r, _, _, status = patch_internal(
+                self.known_resource,
+                data,
+                concurrency_check=False,
+                mongo_options=mongo_options,
                 **{"_id": self.item_id}
             )
         db_value = self.compare_patch_with_get(test_field, r)


### PR DESCRIPTION
This is done by passing the options directly into the `eve.Mongo` `find_one` method.
The work doesn't cover adding arguments to find_one_raw or find since
they aren't needed to fix the bug.

I explored adding a fluid type interface for with_optios to the eve
PyMongos/Mongo/DataLayer classes but it was really clunky and I'd be
worried that such a fundamental change wouldn't be appropriate here.