### PR TITLE
Expose media endpoint only if RETURN_MEDIA_AS_URL is True

### DIFF
--- a/eve/flaskapp.py
+++ b/eve/flaskapp.py
@@ -180,7 +180,10 @@ class Eve(Flask, Events):
             self.auth = None
 
         self._init_url_rules()
-        self._init_media_endpoint()
+
+        if self.config["RETURN_MEDIA_AS_URL"]:
+            self._init_media_endpoint()
+
         self._init_schema_endpoint()
 
         if self.config["OPLOG"] is True:


### PR DESCRIPTION
According to the documentation `RETURN_MEDIA_AS_URL` behaves as follows:
> Set it to True to enable serving media files at a dedicated media endpoint. Defaults to False.

However, this is not entirely correct. Serving media files at a dedicated media endpoint is, in the current version of Eve, enabled regardless of what the value of `RETURN_MEDIA_AS_URL` is. **This poses a serious security risk** as most users that use `RETURN_MEDIA_AS_BASE64_STRING = True `  won't be aware that their files can be served publicly via a url even if they explicitly set `RETURN_MEDIA_AS_URL` to `False` (it's False by default).

This change simply makes sure the media endpoint is enabled **only** if `RETURN_MEDIA_AS_URL` is `True`.

Side note: Current version of Eve does though allow us to disable the media endpoint by setting `MEDIA_ENDPOINT` to `False`, but this is an undocumented feature and users can only be made aware of it[ by browsing through this source code here](https://github.com/pyeve/eve/blob/master/eve/flaskapp.py#L1066). In order not to introduce too many breaking changes I decided to keep this code as is as it's unlikely to cause harm.
