### PR TITLE
Pass original updates in PATCH callbacks

### DIFF
--- a/eve/default_settings.py
+++ b/eve/default_settings.py
@@ -274,3 +274,7 @@ MONGO_OPTIONS = {"connect": True, "tz_aware": True}
 # this means fields will be reset their the default value, if any, unless
 # contained in the patch body.
 NORMALIZE_ON_PATCH = True
+
+# if true, the on_updated callback in PATCH requests gets the original data
+# in the `updates` argument, instead of the updates merged with nested data.
+ORIG_UPDATES_IN_CALLBACKS = False

--- a/eve/flaskapp.py
+++ b/eve/flaskapp.py
@@ -687,6 +687,9 @@ class Eve(Flask, Events):
             "normalize_dotted_fields", self.config["NORMALIZE_DOTTED_FIELDS"]
         )
         settings.setdefault("normalize_on_patch", self.config["NORMALIZE_ON_PATCH"])
+        settings.setdefault(
+            "orig_updates_in_callbacks", self.config["ORIG_UPDATES_IN_CALLBACKS"]
+        )
         # empty schemas are allowed for read-only access to resources
         schema = settings.setdefault("schema", {})
         self.set_schema_defaults(schema, settings["id_field"])

--- a/eve/tests/__init__.py
+++ b/eve/tests/__init__.py
@@ -434,6 +434,7 @@ class TestBase(TestMinimal):
         self.item_etag = contact[ETAG]
         self.item_ref = contact["ref"]
         self.item_rows = contact["rows"]
+        self.item_city = contact["location"]["city"]
         self.item_id_url = "/%s/%s" % (
             self.domain[self.known_resource]["url"],
             self.item_id,

--- a/eve/tests/methods/patch_atomic_concurrency.py
+++ b/eve/tests/methods/patch_atomic_concurrency.py
@@ -30,7 +30,7 @@ def get_document_simulate_concurrent_update(*args, **kwargs):
     """
     Hostile version of get_document
 
-    This simluates another process updating MongoDB (and ETag) in
+    This simulates another process updating MongoDB (and ETag) in
     eve.methods.patch.patch_internal() during the critical area
     between get_document() and app.data.update()
     """


### PR DESCRIPTION
The merge_nested_documents operation masks the original update request in the post-PATCH callbacks.
This setting adds support to see the original PATCH data.