### PR TITLE
Drop Python 3.5 support and update pypy3 version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,4 +25,4 @@ matrix:
     - env: TOXENV=py39
       python: "3.9"
     - env: TOXENV=pypy3
-      python: "pypy3.5-6.0"
+      python: "pypy3.6-7.3.1"

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,6 @@ matrix:
       python: "3.7"
     - env: TOXENV=py27
       python: "2.7"
-    - env: TOXENV=py35
-      python: "3.5"
     - env: TOXENV=py36
       python: "3.6"
     - env: TOXENV=py37

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ Here you can see the full list of changes between each Eve release.
 In Development
 ---------------
 
-- Added Python 3.9 support
+- Added Python 3.9 support and dropped Python 3.5 support
 
 Version 1.1.5
 -------------

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     test_suite="eve.tests",
     install_requires=INSTALL_REQUIRES,
     extras_require=EXTRAS_REQUIRE,
-    python_requires=">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*, !=3.4.*",
+    python_requires=">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*, !=3.4.*, !=3.5.*",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Environment :: Web Environment",
@@ -59,7 +59,6 @@ setup(
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py27,py35,py36,py37,py38,py39,pypy3,linting
+envlist=py27,py36,py37,py38,py39,pypy3,linting
 
 [testenv]
 extras=tests


### PR DESCRIPTION
As discussed in #1437, drop Python 3.5 support (and looking forward to dropping 2.7).

And update pypy3 to the latest version in travis.

How about adding GitHub Actions CI?