### PR TITLE
do not return related fields if the field is a list and empty

### DIFF
--- a/eve/methods/common.py
+++ b/eve/methods/common.py
@@ -754,7 +754,7 @@ def resolve_data_relation_links(document, resource):
         if "data_relation" not in field_def:
             continue
 
-        if field in document and document[field] is not None:
+        if field in document and document[field] is not None and document[field] is not []:
             related_links = []
 
             # Make the code DRY for list of linked relation and single linked relation


### PR DESCRIPTION
if our resource have a relationship with empty data (many to many or one to many in eve-sqlalchemy ), the related field in _links is returned with an empty list, making test_getitem_data_relation_hateoas failing