### PR TITLE
Fix 500 error with empty token/bearer

### DIFF
--- a/eve/auth.py
+++ b/eve/auth.py
@@ -274,7 +274,7 @@ class TokenAuth(BasicAuth):
         if not auth and request.headers.get("Authorization"):
             auth = request.headers.get("Authorization").strip()
             if auth.lower().startswith(("token", "bearer")):
-                auth = auth.split(" ")[1]
+                auth = auth.split(" ")[1] if " " in auth else ""
 
         if auth:
             self.set_user_or_token(auth)


### PR DESCRIPTION
Some of the browser will set the authorization header as

`Authorization: Token `

with an empty token.

This will make the TokenAuth fail with 500 error
This PR adds a check for empty token