### PR TITLE
Update docs and tests regarding pagination of empty resources

### DIFF
--- a/docs/features.rst
+++ b/docs/features.rst
@@ -100,8 +100,8 @@ These additional fields are automatically handled by the API (clients don't
 need to provide them when adding/editing resources).
 
 The ``_meta`` field provides pagination data and will only be there if
-:ref:`Pagination` has been enabled (it is by default) and there is at least one
-document being returned. The ``_links`` list provides HATEOAS_ directives.
+:ref:`Pagination` has been enabled (it is by default). The ``_links`` list
+provides HATEOAS_ directives.
 
 .. _subresources:
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -91,6 +91,11 @@ Try requesting ``people`` now:
           "href": "/",
           "title": "home"
         }
+      },
+      "_meta": {
+        "max_results": 25,
+        "page": 1,
+        "total": 0
       }
     }
 

--- a/eve/tests/methods/get.py
+++ b/eve/tests/methods/get.py
@@ -27,6 +27,8 @@ class TestGet(TestBase):
         self.assertResourceLink(links, self.empty_resource)
         self.assertHomeLink(links)
 
+        self.assertPagination(response, 1, 0, 25)
+
     def test_get_max_results(self):
         maxr = 10
         response, status = self.get(self.known_resource, "?max_results=%d" % maxr)
@@ -381,7 +383,7 @@ class TestGet(TestBase):
             self.assertTrue(r[self.app.config["DATE_CREATED"]] != self.epoch)
 
     def test_get_static_projection(self):
-        """ Test that static projections are honoured """
+        """Test that static projections are honoured"""
         response, status = self.get(self.different_resource)
         self.assert200(status)
 
@@ -1279,21 +1281,21 @@ class TestGet(TestBase):
         self.assert200(status)
 
     def test_get_invalid_idfield_cors(self):
-        """ test that #381 is fixed. """
+        """test that #381 is fixed."""
         request = "/%s/badid" % self.known_resource
         self.app.config["X_DOMAINS"] = "*"
         r = self.test_client.get(request, headers=[("Origin", "test.com")])
         self.assert404(r.status_code)
 
     def test_get_invalid_where_syntax(self):
-        """ test that 'where' syntax with unknown '$' operator returns 400. """
+        """test that 'where' syntax with unknown '$' operator returns 400."""
         response, status = self.get(
             self.known_resource, '?where={"field": {"$foo": "bar"}}'
         )
         self.assert400(status)
 
     def test_get_invalid_sort_syntax(self):
-        """ test that invalid sort syntax returns a 400 """
+        """test that invalid sort syntax returns a 400"""
         response, status = self.get(self.known_resource, '?sort=[("prog":1)]')
         self.assert400(status)
         response, status = self.get(self.known_resource, '?sort="firstname"')


### PR DESCRIPTION
According to the code, the presence of the pagination data (the `_meta` field) in the payload is only determined by the pagination setting, no matter the number of documents returned. Docs and tests are updated in order to clarify it.

Missing Black code-style changes are applied so that `pre-commit` passes.