### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/tutorials/account_management.rst
+++ b/docs/tutorials/account_management.rst
@@ -5,7 +5,7 @@ RESTful Account Management
     This tutorial assumes that you've read the :ref:`quickstart` and the
     :ref:`auth` guides.
 
-Except for the relatively rare occurence of open (and generally read-only) public
+Except for the relatively rare occurrence of open (and generally read-only) public
 APIs, most services are only accessible to authenticated users.  A common
 pattern is that users create their account on a website or with a mobile
 application.  Once they have an account, they are allowed to consume one or more

--- a/eve/methods/delete.py
+++ b/eve/methods/delete.py
@@ -204,7 +204,7 @@ def delete(resource, **lookup):
        'on_deleted_resource' raised after performing the delete
 
     .. versionchanged:: 0.3
-       Support for the lookup filter, which allows for develtion of
+       Support for the lookup filter, which allows for devolution of
        sub-resources (only delete documents that match a given condition).
 
     .. versionchanged:: 0.0.4

--- a/eve/tests/config.py
+++ b/eve/tests/config.py
@@ -424,7 +424,7 @@ class TestConfig(TestBase):
 
     def test_oplog_config(self):
 
-        # if OPLOG_ENDPOINT is eanbled the endoint is included with the domain
+        # if OPLOG_ENDPOINT is enabled the endoint is included with the domain
         self.app.config["OPLOG_ENDPOINT"] = "oplog"
         self.app._init_oplog()
         self.assertOplog("oplog", "oplog")

--- a/eve/tests/methods/patch.py
+++ b/eve/tests/methods/patch.py
@@ -739,7 +739,7 @@ class TestPatch(TestBase):
 
     def test_patch_dependent_field_on_origin_document(self):
         """Test that when patching a field which is dependent on another field's
-        existance, and this other field is not provided in the patch, but does
+        existence, and this other field is not provided in the patch, but does
         exist on the persisted document, the patch will be accepted.
 
         The value on the document can be there either because is was set

--- a/eve/tests/methods/post.py
+++ b/eve/tests/methods/post.py
@@ -828,7 +828,7 @@ class TestPost(TestBase):
 
     def test_post_readonly_in_dict(self):
         # Test that a post with a readonly field inside a dict is properly
-        # validated (even if it has a defult value)
+        # validated (even if it has a default value)
         del self.domain["contacts"]["schema"]["ref"]["required"]
         test_field = "dict_with_read_only"
         test_value = {"read_only_in_dict": "default"}


### PR DESCRIPTION
There are small typos in:
- docs/tutorials/account_management.rst
- eve/methods/delete.py
- eve/tests/config.py
- eve/tests/methods/patch.py
- eve/tests/methods/post.py

Fixes:
- Should read `occurrence` rather than `occurence`.
- Should read `existence` rather than `existance`.
- Should read `enabled` rather than `eanbled`.
- Should read `default` rather than `defult`.
- Should read `devolution` rather than `develtion`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md