### PR TITLE
Fix issue  #1486

### DIFF
--- a/eve/utils.py
+++ b/eve/utils.py
@@ -348,7 +348,7 @@ def document_etag(value, ignore_fields=None):
             "javaLegacy": UuidRepresentation.JAVA_LEGACY,
         }
         return uuid_map[
-            config.MONGO_OPTIONS.get("uuidRepresentation", UuidRepresentation.STANDARD)
+            config.MONGO_OPTIONS.get("uuidRepresentation", "standard")
         ]
 
     if ignore_fields:


### PR DESCRIPTION
This solution seems to fit the current code best, but alternatively one could get the value earlier and return  `UuidRepresentation.STANDARD` early if the value is of a non-string type.

This PR is a fix to [issue #1486](https://github.com/pyeve/eve/issues/1486)