### PR TITLE
[wip] Invalid bearer token should be 401 instead of 500

### DIFF
--- a/eve/tests/auth.py
+++ b/eve/tests/auth.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import pytest
 import simplejson as json
 
 from bson import ObjectId
@@ -337,6 +338,20 @@ class TestBearerTokenAuth(TestTokenAuth):
         r = self.test_client.get("/", headers=self.valid_auth)
         # will fail because check_auth() is not implemented in the custom class
         self.assert500(r.status_code)
+
+    def test_invalid_auth_header(self):
+        # Setup.
+        self.app = Eve(settings=self.settings_file, auth=ValidTokenAuth)
+        self.test_client = self.app.test_client()
+
+        cases = ["", "invalid header", "bearertokenbutalsoinvalid"]
+        for case in cases:
+            with self.subTest(case=case):
+                # Attempt to fetch the root.
+                response = self.test_client.get("/", headers=[("Authorization", case)])
+
+                # Validate that the request fails with a HTTP/401 error.
+                self.assert401(response.status_code)
 
 
 class TestCustomTokenAuth(TestTokenAuth):


### PR DESCRIPTION
When passing an invalid authorization token header, an internal server error is raised due to the `split()` function assuming that the header will always contain a space -- whereas this should be a client error instead.

Contains tests