### PR TITLE
Ability to modify the pagination limit on a per-resource basis

### DIFF
--- a/eve/tests/methods/get.py
+++ b/eve/tests/methods/get.py
@@ -45,6 +45,21 @@ class TestGet(TestBase):
         resource = response["_items"]
         self.assertEqual(len(resource), self.app.config["PAGINATION_LIMIT"])
 
+    def test_get_max_results_overridden(self):
+        # Generate 50 contacts.
+        self.random_contacts(num=50)
+        
+        # Set the max pagination limit to 7.
+        self.app.config["DOMAIN"][self.known_resource]["pagination_limit"] = 7
+        
+        # Attempt to get all 50 contacts in one request.
+        response, status = self.get(self.known_resource, "?max_results=50")
+        self.assert200(status)
+        
+        # Validate that the response only contains 10 contacts.
+        resource = response["_items"]
+        self.assertEqual(len(resource), 7)
+
     def test_get_custom_max_results(self):
         self.app.config["QUERY_MAX_RESULTS"] = "size"
         maxr = 10

--- a/eve/utils.py
+++ b/eve/utils.py
@@ -160,8 +160,10 @@ def parse_request(resource):
 
         # TODO should probably return a 400 if 'max_results' < 1 or
         # non-numeric
-        if r.max_results > config.PAGINATION_LIMIT:
-            r.max_results = config.PAGINATION_LIMIT
+        # Fetch the custom pagination limit from the schema, default to the global one.
+        pagination_limit = settings.get("pagination_limit") or config.PAGINATION_LIMIT
+        if r.max_results > pagination_limit:
+            r.max_results = pagination_limit
 
     def etag_parse(challenge):
         if challenge in headers:


### PR DESCRIPTION
This PR implements the ability to modify the pagination limit on a per-resource basis.

Example use case: a collection that contains very small documents could have a higher pagination limit, whereas a collection with primarily large documents could have a stricter/lower pagination limit.