### PR TITLE
datetime.utcnow -> datetime.now(UTC)

### DIFF
--- a/eve/methods/common.py
+++ b/eve/methods/common.py
@@ -14,7 +14,7 @@ import re
 import time
 from collections import Counter
 from copy import copy
-from datetime import datetime, timezone
+from datetime import datetime, UTC
 from functools import wraps
 
 import simplejson as json
@@ -1531,4 +1531,4 @@ def oplog_push(resource, document, op, id=None):
 
 
 def utcnow():
-    return datetime.utcnow().replace(microsecond=0, tzinfo=timezone.utc)
+    return datetime.now(UTC).replace(microsecond=0)

--- a/eve/methods/common.py
+++ b/eve/methods/common.py
@@ -14,7 +14,7 @@ import re
 import time
 from collections import Counter
 from copy import copy
-from datetime import datetime, UTC
+from datetime import datetime, timezone
 from functools import wraps
 
 import simplejson as json
@@ -1531,4 +1531,4 @@ def oplog_push(resource, document, op, id=None):
 
 
 def utcnow():
-    return datetime.now(UTC).replace(microsecond=0)
+    return datetime.now(timezone.utc).replace(microsecond=0)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py3{11,10,9,8,7},pypy3{8,7},linting
+envlist=py3{12,11,10,9},pypy3{10,9},linting
 
 [testenv]
 extras=tests


### PR DESCRIPTION
Fixes deprecation warnings in Python 3.12

<img width="1200" alt="Screenshot 2024-06-11 at 12 07 07" src="https://github.com/pyeve/eve/assets/1122069/558f7bd5-1749-4d99-bdfe-f41777baa730">
