### PR TITLE
fix: type-checking Eve dynamic attrs

### DIFF
--- a/eve/flaskapp.py
+++ b/eve/flaskapp.py
@@ -14,6 +14,7 @@ import fnmatch
 import os
 import sys
 import warnings
+from typing import TYPE_CHECKING
 
 from events import Events
 from flask import Flask
@@ -1102,3 +1103,6 @@ class Eve(Flask, Events):
                 "HTTP_X_HTTP_METHOD_OVERRIDE", environ["REQUEST_METHOD"]
             ).upper()
         return super().__call__(environ, start_response)
+
+    if TYPE_CHECKING:
+        def __setattr__(self, name, value): ...


### PR DESCRIPTION
## Description
Adding [event hooks](https://docs.python-eve.org/en/stable/features.html#eventhooks) to an Eve instance produces types errors such as:
```
Cannot assign to attribute "on_insert_<redacted>" for class "Eve"
  Attribute "on_insert_<redacted>" is unknown. Pylance[reportAttributeAccessIssue](https://github.com/microsoft/pyright/blob/main/docs/configuration.md#reportAttributeAccessIssue)
```
by [pyright](https://github.com/microsoft/pyright)/pylance. The pyright maintainer's [advice](https://github.com/microsoft/pyright/issues/153#issuecomment-504040459) for such cases is to add a `__setattr__` to such classes which allow dynamic attributes. Doing that here. Note it's behind the `typing.TYPE_CHECKING` guard which makes it have no effect at runtime, thus it only impacts type-checking. I've confirmed this fixes the type errors on pyright.

### Why care about `pyright`?
It's the more correct python type-checker (see [official python typing benchmarks](https://htmlpreview.github.io/?https://github.com/python/typing/blob/main/conformance/results/results.html)). Chances are other type-checkers (most importantly `mypy`) may not fail on this temporarily only due to their lack of coverage.
