### PR TITLE
Correct on_deleted_resource call signature in docs

### DIFF
--- a/docs/features.rst
+++ b/docs/features.rst
@@ -1419,10 +1419,10 @@ Let's see an overview of what events are available:
 |       |        |      || ``def event(originals, lookup)``                |
 |       |        +------+--------------------------------------------------+
 |       |        |After || ``on_deleted_resource``                         |
-|       |        |      || ``def event(resource_name, item)``              |
+|       |        |      || ``def event(resource_name)``                    |
 |       |        |      +--------------------------------------------------+
 |       |        |      || ``on_deleted_resource_<resource_name>``         |
-|       |        |      || ``def event(item)``                             |
+|       |        |      || ``def event()``                                 |
 +-------+--------+------+--------------------------------------------------+
 
 


### PR DESCRIPTION
I was confused from the docs about what the "item" in the on_deleted_resource would be, but after looking at [the code](https://github.com/pyeve/eve/blob/172f3f251bc34d7c59cd72c9b67873b99ba0f486/eve/methods/delete.py#L254-L255) it seems this is an oversight in the docs, those functions are only called with the resource name (or nothing if the hook is resource specific). This updates the docs to match